### PR TITLE
Feat/post data result

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::state::DataRequest;
+use crate::state::{DataRequest, DataResult};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
 #[cw_serde]
@@ -7,7 +7,7 @@ pub struct InstantiateMsg {}
 #[cw_serde]
 pub enum ExecuteMsg {
     PostDataRequest { value: String },
-    PostDataResult { dr_id: u128 },
+    PostDataResult { dr_id: u128, result: String },
 }
 
 #[cw_serde]
@@ -26,5 +26,5 @@ pub struct GetDataRequestResponse {
 
 #[cw_serde]
 pub struct GetDataResultResponse {
-    pub value: Option<DataRequest>,
+    pub value: Option<DataResult>,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,11 +7,17 @@ pub struct DataRequest {
     pub value: String,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, JsonSchema)]
+pub struct DataResult {
+    pub value: String,
+    pub result: String,
+}
+
 /// Upon posting a data request, it is added to this map with a unique auto-incrementing ID
 pub const DATA_REQUESTS_POOL: Map<u128, DataRequest> = Map::new("data_requests_pool");
 
 /// Once resolved, data requests are moved to this map and removed from the pool
-pub const DATA_RESULTS: Map<u128, DataRequest> = Map::new("data_results");
+pub const DATA_RESULTS: Map<u128, DataResult> = Map::new("data_results");
 
 /// An auto-incrementing counter for the data requests
 pub const DATA_REQUESTS_COUNT: Item<u128> = Item::new("data_requests_count");


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Once resolved, data requests should occupy a different storage location other than the pool of unresolved data requests to make filtering easier.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- implemented function `post_data_result` that requires the id to already exist in the pool, moves it to the results mapping, and deletes it from the pool
- implemented function `get_data_result` that reads just one data result, similar to the existing `get_data_request()` fn
- created a test to ensure correct behavior

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

- new `post_data_result()` function ensures that only data requests from the pool can be added to the results.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #3 
Closes #5
Blocked by PR #7 