### PR TITLE
feat: create functions for registering and unregistering DR executors

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,13 +1,24 @@
-use crate::state::{DataRequest, DataResult};
+use crate::state::{DataRequest, DataRequestExecutor, DataResult};
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Addr;
 
 #[cw_serde]
 pub struct InstantiateMsg {}
 
 #[cw_serde]
 pub enum ExecuteMsg {
-    PostDataRequest { value: String },
-    PostDataResult { dr_id: u128, result: String },
+    PostDataRequest {
+        value: String,
+    },
+    PostDataResult {
+        dr_id: u128,
+        result: String,
+    },
+    RegisterDataRequestExecutor {
+        bn254_public_key: String,
+        multi_address: String,
+    },
+    UnregisterDataRequestExecutor {},
 }
 
 #[cw_serde]
@@ -22,6 +33,8 @@ pub enum QueryMsg {
     },
     #[returns(GetDataResultResponse)]
     GetDataResult { dr_id: u128 },
+    #[returns(GetDataRequestExecutorResponse)]
+    GetDataRequestExecutor { executor: Addr },
 }
 
 #[cw_serde]
@@ -37,4 +50,9 @@ pub struct GetDataRequestsResponse {
 #[cw_serde]
 pub struct GetDataResultResponse {
     pub value: Option<DataResult>,
+}
+
+#[cw_serde]
+pub struct GetDataRequestExecutorResponse {
+    pub value: Option<DataRequestExecutor>,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,12 @@ pub struct DataResult {
     pub result: String,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, JsonSchema)]
+pub struct DataRequestExecutor {
+    pub bn254_public_key: String,
+    pub multi_address: String,
+}
+
 /// Upon posting a data request, it is added to this map with a unique auto-incrementing ID
 pub const DATA_REQUESTS_POOL: Map<u128, DataRequest> = Map::new("data_requests_pool");
 
@@ -21,3 +28,7 @@ pub const DATA_RESULTS: Map<u128, DataResult> = Map::new("data_results");
 
 /// An auto-incrementing counter for the data requests
 pub const DATA_REQUESTS_COUNT: Item<u128> = Item::new("data_requests_count");
+
+/// A map of data request executors (of address to info) that have not yet been marked as active
+pub const INACTIVE_DATA_REQUEST_EXECUTORS: Map<Addr, DataRequestExecutor> =
+    Map::new("inactive_data_request_executors");


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Data request executors must be stored somewhere on a registry so that they can be marked eligible to participate and collect rewards.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Global mapping for inactive data request executors. The ID is the account that originally called register
- Functions for registering and unregistering data request executors with some TODO comments for future tasks
- Query function for viewing info associated with DR executor

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Two tests for registering and unregistering data request executors, checking with a query before and after performing the mutative functions

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #13
creating follow-up issues for BN245 key verification 
