### PR TITLE
Add Github Actions manual job to build, minify, create and instantiate contract to testnet

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -86,7 +86,7 @@ jobs:
           echo "txhash=$TXHASH" >> $GITHUB_ENV
 
       - name: Wait for the transaction to be included in a block
-        run: sleep 6
+        run: sleep 12
 
       - name: Find the code ID
         env:
@@ -113,7 +113,7 @@ jobs:
           echo "txhash=$TXHASH" >> $GITHUB_ENV
 
       - name: Wait for the transaction to be included in a block
-        run: sleep 6
+        run: sleep 12
 
       - name: Find the contract address
         env:


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Make it easy to one-click deploy the contract to testnet!

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Outputs the contract address in the step "Find the contract address"
- Manual dispatch that requires triggerer to be a SEDA member (pending password setup in https://github.com/sedaprotocol/seda-chain/issues/12)
- uses rust-optimizer to create the smallest possible binary
- downloads seda-chaind binary and encrypted keyring from Google Drive. The encrypted keyring archive includes my own personal testnet key preloaded with funds to deploy and instantiate the contract.

Uses secrets (I already set them on this repo):
- KEYRING_PASSWORD - randomly generated password to decrypt keyring archive
- KEYRING_FILE_ID - path of Google Drive link to encrypted keyring archive that only includes my personal dev account key
- SEDACHAIND_FILE_ID - path of Google Drive link to seda-chaind x86-64 binary (shouldn't need to be updated in the future, but we have to use it instead of something like wasmd to get the correct account prefixes)
- TESTNET_NODE_URL - TCP URL to testnet node
- DEV_ACCOUNT - my personal testnet dev account address, preloaded with funds to deploy and instantiate the contract

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested on a private fork of this repo.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #15 