### PR TITLE
chore: manual deploy CI secret

### DIFF
--- a/.github/workflows/Deploy-WASM-Storage.yml
+++ b/.github/workflows/Deploy-WASM-Storage.yml
@@ -1,31 +1,29 @@
 on:
   workflow_dispatch:
+    inputs:
+      password:
+        required: true
 
 name: Deploy WASM storage to testnet
 
 jobs:
-  check_actor:
+    check_pass:
+    name: Check password
     runs-on: ubuntu-latest
     outputs:
       is_allowed: ${{ steps.check.outputs.is_allowed }}
     steps:
       - id: check
         run: |
-          allowed_users=("FranklinWaller" "gluax" "jamesondh" "mariocao" "mennatbuelnaga" "Thomasvdam")
-          for user in "${allowed_users[@]}"
-          do
-            # The if statement checks who was the actor that triggered the CI seeing if it's an approved user.
-            # The triggering_actor is the person who possibly tried to re-run the CI from the actions page.
-            # If this exists we check if it's also an approved user.
-            if [[ "${{ github.actor }}" == "${user}" && ("${{ github.event.inputs.triggering_actor }}" == "${user}" || "${{ github.event.inputs.triggering_actor }}" == "") ]]; then
-              echo "is_allowed=true" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-          done
-          echo "is_allowed=false" >> $GITHUB_OUTPUT
+          password=${{ secrets.CI_PASSWORD }}
+          if [[ "${{ github.event.inputs.password }}" == "${password}" ]]; then
+            echo "is_allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_allowed=false" >> $GITHUB_OUTPUT
+          fi
   deploys:
-    needs: check_actor
-    if: ${{ needs.check_actor.outputs.is_allowed == 'true' }}
+    needs: check_pass
+    if: ${{ needs.check_pass.outputs.is_allowed == 'true' }}
     name: Deploy
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +33,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
+          profile: minimal 
           toolchain: 1.65.0
           target: wasm32-unknown-unknown
           override: true

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,31 +1,30 @@
 on:
   workflow_dispatch:
+    inputs:
+      password:
+        required: true
 
 name: Deploy seda-mainchain-contracts to testnet
 
 jobs:
-  check_actor:
+  check_pass:
+    name: Check password
     runs-on: ubuntu-latest
     outputs:
       is_allowed: ${{ steps.check.outputs.is_allowed }}
     steps:
       - id: check
         run: |
-          allowed_users=("FranklinWaller" "gluax" "jamesondh" "mariocao" "mennatbuelnaga" "Thomasvdam")
-          for user in "${allowed_users[@]}"
-          do
-            # The if statement checks who was the actor that triggered the CI seeing if it's an approved user.
-            # The triggering_actor is the person who possibly tried to re-run the CI from the actions page.
-            # If this exists we check if it's also an approved user.
-            if [[ "${{ github.actor }}" == "${user}" && ("${{ github.event.inputs.triggering_actor }}" == "${user}" || "${{ github.event.inputs.triggering_actor }}" == "") ]]; then
-              echo "is_allowed=true" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-          done
-          echo "is_allowed=false" >> $GITHUB_OUTPUT
+          password=${{ secrets.CI_PASSWORD }}
+          if [[ "${{ github.event.inputs.password }}" == "${password}" ]]; then
+            echo "is_allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_allowed=false" >> $GITHUB_OUTPUT
+          fi
+
   deploys:
-    needs: check_actor
-    if: ${{ needs.check_actor.outputs.is_allowed == 'true' }}
+    needs: check_pass
+    if: ${{ needs.check_pass.outputs.is_allowed == 'true' }}
     name: Deploy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

It's easier to onboard new developers using a CI secret instead of manually specifying allowed users.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Use a workflow dispatch input and secret variable to allow running the rest of the workflow.

I also set CI_PASSWORD already for this repository.

## Testing

Tested on a fork of this repository

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Related to https://github.com/sedaprotocol/seda-chain/issues/12
