### PR TITLE
refactor: use errors instead of assertions/panics

### DIFF
--- a/packages/seda-chain-contracts/src/error.rs
+++ b/packages/seda-chain-contracts/src/error.rs
@@ -16,4 +16,16 @@ pub enum ContractError {
     InvalidDataRequestId(Hash, Hash),
     #[error("Data request already exists")]
     DataRequestAlreadyExists,
+    #[error("Caller is not an eligible data request executor")]
+    IneligibleExecutor,
+    #[error("Caller has already committed on this data request")]
+    AlreadyCommitted,
+    #[error("Reveal stage has not started yet")]
+    RevealNotStarted,
+    #[error("Executor has not committed on this data request")]
+    NotCommitted,
+    #[error("Executor has already revealed on this data request")]
+    AlreadyRevealed,
+    #[error("Revealed result does not match the committed result")]
+    RevealMismatch,
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Replace some assertions/panics with errors with error strings.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Added new errors to error enum
- Replace assertions/panics with error

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

- Confirm tests still run

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

I noticed some errors aren't being tested, so I created this PR as to keep this one minimal: https://github.com/sedaprotocol/seda-chain-contracts/issues/58