### PR TITLE
fix: update hashing function to latest spec

### DIFF
--- a/packages/data-requests/src/data_request.rs
+++ b/packages/data-requests/src/data_request.rs
@@ -155,7 +155,6 @@ mod dr_tests {
     use crate::msg::InstantiateMsg;
     use crate::state::DataRequestInputs;
     use crate::utils::hash_data_request;
-    use crate::utils::hash_update;
     use common::msg::DataRequestsExecuteMsg as ExecuteMsg;
     use common::msg::DataRequestsQueryMsg as QueryMsg;
     use common::msg::GetDataRequestResponse;
@@ -163,7 +162,6 @@ mod dr_tests {
     use common::state::Reveal;
     use common::types::Bytes;
     use common::types::Commitment;
-    use common::types::Memo;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coins, from_binary};
     use sha3::Digest;
@@ -205,17 +203,15 @@ mod dr_tests {
 
         // set by relayer and SEDA protocol
         let seda_payload: Bytes = Vec::new();
-
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = "hello world".to_string();
         let payback_address: Bytes = Vec::new();
+
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 1;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hasher.update(value);
-        let binary_hash = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo1: Memo = binary_hash.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo1 = hasher.finalize().to_vec();
 
         let dr_inputs1 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
@@ -275,15 +271,15 @@ mod dr_tests {
         let seda_payload: Bytes = Vec::new();
         let commits: HashMap<String, Commitment> = HashMap::new();
         let reveals: HashMap<String, Reveal> = HashMap::new();
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = "hello world".to_string();
+
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 1;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hasher.update(value);
-        let binary_hash = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo1: Memo = binary_hash.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo1 = hasher.finalize().to_vec();
+
         let dr_inputs1 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
             tally_binary_id: tally_binary_id.clone(),
@@ -358,17 +354,16 @@ mod dr_tests {
 
         // set by relayer and SEDA protocol
         let seda_payload: Bytes = Vec::new();
-
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = 1;
         let payback_address: Bytes = Vec::new();
+
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 1;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hash_update(&mut hasher, &value);
-        let binary_hash1 = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo1: Memo = binary_hash1.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo1 = hasher.finalize().to_vec();
+
         let dr_inputs1 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
             tally_binary_id: tally_binary_id.clone(),
@@ -385,15 +380,13 @@ mod dr_tests {
         };
         let constructed_dr_id1 = hash_data_request(dr_inputs1);
 
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = 2;
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 2;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hash_update(&mut hasher, &value);
-        let binary_hash2 = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo2: Memo = binary_hash2.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo2 = hasher.finalize().to_vec();
 
         let dr_inputs2 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
@@ -411,15 +404,13 @@ mod dr_tests {
         };
         let constructed_dr_id2 = hash_data_request(dr_inputs2);
 
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = 3;
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 3;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hash_update(&mut hasher, &value);
-        let binary_hash3 = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo3: Memo = binary_hash3.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo3 = hasher.finalize().to_vec();
 
         let dr_inputs3 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
@@ -522,15 +513,13 @@ mod dr_tests {
         let commits: HashMap<String, Commitment> = HashMap::new();
         let reveals: HashMap<String, Reveal> = HashMap::new();
 
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = 1;
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 1;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hash_update(&mut hasher, &value);
-        let binary_hash1 = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo1: Memo = binary_hash1.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo1 = hasher.finalize().to_vec();
 
         let dr_inputs1 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
@@ -548,15 +537,13 @@ mod dr_tests {
         };
         let constructed_dr_id1 = hash_data_request(dr_inputs1);
 
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = 2;
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 2;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hash_update(&mut hasher, &value);
-        let binary_hash2 = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo2: Memo = binary_hash2.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo2 = hasher.finalize().to_vec();
 
         let dr_inputs2 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
@@ -574,15 +561,13 @@ mod dr_tests {
         };
         let constructed_dr_id2 = hash_data_request(dr_inputs2);
 
-        let chain_id = 31337;
-        let nonce = 1;
-        let value = 3;
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 3;
         let mut hasher = Keccak256::new();
-        hash_update(&mut hasher, &chain_id);
-        hash_update(&mut hasher, &nonce);
-        hash_update(&mut hasher, &value);
-        let binary_hash3 = format!("0x{}", hex::encode(hasher.finalize()));
-        let memo3: Memo = binary_hash3.clone().into_bytes();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo3 = hasher.finalize().to_vec();
 
         let dr_inputs3 = DataRequestInputs {
             dr_binary_id: dr_binary_id.clone(),
@@ -796,5 +781,59 @@ mod dr_tests {
             },
             response
         );
+    }
+
+    #[test]
+    fn test_hash_data_request() {
+        let mut deps = mock_dependencies();
+
+        // instantiate contract
+        let msg = InstantiateMsg {
+            token: "token".to_string(),
+            proxy: "proxy".to_string(),
+        };
+        let info = mock_info("creator", &coins(2, "token"));
+        instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        let dr_binary_id: Hash = "dr_binary_id".to_string();
+        let dr_inputs: Bytes = "dr_inputs".to_string().into_bytes();
+        let tally_binary_id: Hash = "tally_binary_id".to_string();
+        let tally_inputs: Bytes = "tally_inputs".to_string().into_bytes();
+
+        let replication_factor: u16 = 123;
+
+        // set by dr creator
+        let gas_price: u128 = 456;
+        let gas_limit: u128 = 789;
+
+        // set by relayer and SEDA protocol
+        let seda_payload: Bytes = "seda_payload".to_string().into_bytes();
+        let payback_address: Bytes = "payback_address".to_string().into_bytes();
+
+        // memo
+        let chain_id: u128 = 31337;
+        let nonce: u128 = 1;
+        let mut hasher = Keccak256::new();
+        hasher.update(chain_id.to_be_bytes());
+        hasher.update(nonce.to_be_bytes());
+        let memo = hasher.finalize().to_vec();
+
+        // format inputs
+        let dr_inputs1 = DataRequestInputs {
+            dr_binary_id,
+            tally_binary_id,
+            dr_inputs,
+            tally_inputs,
+            memo,
+            replication_factor,
+            gas_price,
+            gas_limit,
+            seda_payload,
+            payback_address,
+        };
+
+        // reconstruct dr_id
+        let constructed_dr_id1 = hash_data_request(dr_inputs1);
+        println!("constructed_dr_id1: {}", constructed_dr_id1);
     }
 }

--- a/packages/data-requests/src/utils.rs
+++ b/packages/data-requests/src/utils.rs
@@ -20,18 +20,6 @@ pub fn check_eligibility(deps: &DepsMut, dr_executor: Addr) -> Result<bool, Cont
     Ok(query_response.value)
 }
 
-pub fn pad_to_32_bytes(value: &u128) -> [u8; 32] {
-    let mut bytes = [0u8; 32];
-    let small_bytes = &value.to_be_bytes();
-    bytes[(32 - small_bytes.len())..].copy_from_slice(small_bytes);
-    bytes
-}
-
-pub fn hash_update(hasher: &mut Keccak256, value: &u128) {
-    let bytes = pad_to_32_bytes(value);
-    hasher.update(bytes);
-}
-
 pub fn hash_data_request(posted_dr: DataRequestInputs) -> String {
     let mut hasher = Keccak256::new();
     hasher.update(posted_dr.dr_binary_id);
@@ -39,9 +27,7 @@ pub fn hash_data_request(posted_dr: DataRequestInputs) -> String {
     hasher.update(posted_dr.gas_limit.to_be_bytes());
     hasher.update(posted_dr.gas_price.to_be_bytes());
     hasher.update(posted_dr.memo);
-    hasher.update(posted_dr.payback_address);
     hasher.update(posted_dr.replication_factor.to_be_bytes());
-    hasher.update(posted_dr.seda_payload);
     hasher.update(posted_dr.tally_binary_id);
     hasher.update(posted_dr.tally_inputs);
 

--- a/packages/integration-tests/src/data_request.rs
+++ b/packages/integration-tests/src/data_request.rs
@@ -1,10 +1,10 @@
 use crate::tests::utils::{proper_instantiate, USER};
 use common::msg::{GetDataRequestResponse, GetDataRequestsFromPoolResponse, PostDataRequestArgs};
-use common::types::{Bytes, Hash, Memo};
+use common::types::{Bytes, Hash};
 use cosmwasm_std::Addr;
 use cw_multi_test::Executor;
 use data_requests::state::DataRequestInputs;
-use data_requests::utils::{hash_data_request, hash_update};
+use data_requests::utils::hash_data_request;
 use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg};
 use sha3::{Digest, Keccak256};
 
@@ -21,15 +21,12 @@ fn post_data_request() {
     let gas_price: u128 = 10;
     let gas_limit: u128 = 10;
     let seda_payload: Bytes = Vec::new();
-    let chain_id = 31337;
-    let nonce = 1;
-    let value = "test".to_string();
+    let chain_id: u128 = 31337;
+    let nonce: u128 = 1;
     let mut hasher = Keccak256::new();
-    hash_update(&mut hasher, &chain_id);
-    hash_update(&mut hasher, &nonce);
-    hasher.update(value);
-    let binary_hash = format!("0x{}", hex::encode(hasher.finalize()));
-    let memo1: Memo = binary_hash.clone().into_bytes();
+    hasher.update(chain_id.to_be_bytes());
+    hasher.update(nonce.to_be_bytes());
+    let memo1 = hasher.finalize().to_vec();
     let payback_address: Bytes = Vec::new();
     let dr_inputs1 = DataRequestInputs {
         dr_binary_id: dr_binary_id.clone(),

--- a/packages/integration-tests/src/data_result.rs
+++ b/packages/integration-tests/src/data_result.rs
@@ -4,11 +4,11 @@ use common::msg::{
     PostDataRequestArgs,
 };
 use common::state::Reveal;
-use common::types::{Bytes, Hash, Memo};
+use common::types::{Bytes, Hash};
 use cosmwasm_std::Addr;
 use cw_multi_test::Executor;
 use data_requests::state::DataRequestInputs;
-use data_requests::utils::{hash_data_request, hash_update};
+use data_requests::utils::hash_data_request;
 use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg};
 use sha3::{Digest, Keccak256};
 use staking::consts::MINIMUM_STAKE_TO_REGISTER;
@@ -49,15 +49,12 @@ fn commit_reveal_result() {
     let gas_price: u128 = 10;
     let gas_limit: u128 = 10;
     let seda_payload: Bytes = Vec::new();
-    let chain_id = 31337;
-    let nonce = 1;
-    let value = "test".to_string();
+    let chain_id: u128 = 31337;
+    let nonce: u128 = 1;
     let mut hasher = Keccak256::new();
-    hash_update(&mut hasher, &chain_id);
-    hash_update(&mut hasher, &nonce);
-    hasher.update(value);
-    let binary_hash = format!("0x{}", hex::encode(hasher.finalize()));
-    let memo1: Memo = binary_hash.clone().into_bytes();
+    hasher.update(chain_id.to_be_bytes());
+    hasher.update(nonce.to_be_bytes());
+    let memo1 = hasher.finalize().to_vec();
     let payback_address: Bytes = Vec::new();
     let dr_inputs1 = DataRequestInputs {
         dr_binary_id: dr_binary_id.clone(),
@@ -203,15 +200,12 @@ fn ineligible_post_data_result() {
     let gas_price: u128 = 10;
     let gas_limit: u128 = 10;
     let seda_payload: Bytes = Vec::new();
-    let chain_id = 31337;
-    let nonce = 1;
-    let value = "test".to_string();
+    let chain_id: u128 = 31337;
+    let nonce: u128 = 1;
     let mut hasher = Keccak256::new();
-    hash_update(&mut hasher, &chain_id);
-    hash_update(&mut hasher, &nonce);
-    hasher.update(value);
-    let binary_hash = format!("0x{}", hex::encode(hasher.finalize()));
-    let memo1: Memo = binary_hash.clone().into_bytes();
+    hasher.update(chain_id.to_be_bytes());
+    hasher.update(nonce.to_be_bytes());
+    let memo1 = hasher.finalize().to_vec();
     let payback_address: Bytes = Vec::new();
     let dr_inputs1 = DataRequestInputs {
         dr_binary_id: dr_binary_id.clone(),


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The DR hashing function incorrectly includes `payback_address` and `seda_payload`, which are not known by external chains at time of DR creation.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Removed `payback_address` and `seda_payload` from DR hashing function
- Refactored memo hash to remove `value`, keeping only `chain_id` and `nonce`. This is only to reflect how memo is calculated in the EVM contracts, i.e. the CosmWasm contracts don't care about how memo is calculated.
- Removed deprecated util functions `hash_update()` and `pad_to_32_bytes()` since the hashing function no longer requires them

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

- Created a new test `test_hash_data_request()` to isolate the DR hashing function and to mirror an identical test on the EVM repo, see: https://github.com/sedaprotocol/seda-evm-contracts/blob/20fffd45abcdcd16e27c4f8ef0a4c343e0dbc371/test/SedaOracle.t.sol#L110

Currently with the test inputs, the CosmWasm contracts and EVM contracts generate a test DR hash of `0x27e7eec2f319302826ea53ae08b4aac6c4824cc07eafcdaf740501b3d603d0aa`.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Related to https://github.com/sedaprotocol/seda-evm-contracts/issues/13
Created new issue https://github.com/sedaprotocol/seda-chain-contracts/issues/65 because Hash (`dr_binary_id` and `tally_binary_id`) are currently Strings instead of fixed size byte arrays. Also requires the same update on the EVM side.
