### PR TITLE
refactor: return dr_id in response.data in `PostDataRequest` message

### DIFF
--- a/packages/data-requests/src/data_request.rs
+++ b/packages/data-requests/src/data_request.rs
@@ -1,9 +1,10 @@
 #[cfg(not(feature = "library"))]
-use cosmwasm_std::{Deps, DepsMut, MessageInfo, Order, Response, StdResult};
+use cosmwasm_std::{to_binary, Deps, DepsMut, MessageInfo, Order, Response, StdResult};
 
 use crate::state::{DATA_REQUESTS, DATA_REQUESTS_COUNT};
 
 use crate::error::ContractError;
+use crate::msg::PostDataRequestResponse;
 use common::msg::{GetDataRequestResponse, GetDataRequestsFromPoolResponse};
 use common::state::DataRequest;
 use common::types::Hash;
@@ -101,8 +102,13 @@ pub mod data_requests {
         })?;
 
         Ok(Response::new()
-            .add_attribute("action", "post_data_request")
-            .add_attribute("dr_id", posted_dr.dr_id))
+            .set_data(to_binary(&PostDataRequestResponse {
+                dr_id: posted_dr.dr_id.clone(),
+            })?)
+            .add_attributes(vec![
+                ("action", "post_data_request"),
+                ("dr_id", &posted_dr.dr_id),
+            ]))
     }
 
     /// Returns a data request from the pool with the given id, if it exists.

--- a/packages/data-requests/src/msg.rs
+++ b/packages/data-requests/src/msg.rs
@@ -1,7 +1,13 @@
+use common::types::Hash;
 use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub token: String,
     pub proxy: String,
+}
+
+#[cw_serde]
+pub struct PostDataRequestResponse {
+    pub dr_id: Hash,
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Query responses return a Response with the data property. To make it easier to get the data request ID after posting a data request, this PR also returns it in the execute message `PostDataRequest`.

## Explanation of Changes

- return `dr_id` in response.data in `post_data_requests`

I could not identify any other functions where return data is necessary. 

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

n/a, tests still passing

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #51 