### PR TITLE
chore: bump github actions rust toolchain

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.72.1
           target: wasm32-unknown-unknown
           override: true
 
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.72.1
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65.0
+          toolchain: 1.72.1
           target: wasm32-unknown-unknown
 
       - name: Compile optimized WASM contract

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.72.1
           target: wasm32-unknown-unknown
           override: true
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Better maintainability.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Bumped rust version in GitHub workflows to 1.72.1, mainly to fix failing test in this PR: https://github.com/sedaprotocol/seda-chain-contracts/pull/76 since it uses the (previously) unstable library feature `is_some_with`.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested https://github.com/sedaprotocol/seda-chain-contracts/pull/76 with bumped rust version locally.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A