### PR TITLE
fix: rename GH secret `TESTNET_NODE_URL` to `DEVNET_NODE_URL`

### DIFF
--- a/.github/workflows/Deploy-All.yml
+++ b/.github/workflows/Deploy-All.yml
@@ -37,7 +37,7 @@ jobs:
           case "${{ github.event.inputs.network }}" in
             devnet)
               echo "Setting NODE_URL for devnet"
-              echo "NODE_URL=${{ secrets.TESTNET_NODE_URL }}" >> $GITHUB_ENV
+              echo "NODE_URL=${{ secrets.DEVNET_NODE_URL }}" >> $GITHUB_ENV
               ;;
           esac
 

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -63,7 +63,7 @@ jobs:
           case "${{ github.event.inputs.network }}" in
             devnet)
               echo "Setting NODE_URL for devnet"
-              echo "NODE_URL=${{ secrets.TESTNET_NODE_URL }}" >> $GITHUB_ENV
+              echo "NODE_URL=${{ secrets.DEVNET_NODE_URL }}" >> $GITHUB_ENV
               ;;
           esac
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Avoid confusion of networks in deploy scripts once testnet endpoint is added.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- In repository settings, set both `TESTNET_NODE_URL` and `DEVNET_NODE_URL` to the latest devnet endpoint (so the scripts still function until this PR is merged)
- In workflow scripts, updated the devnet network selector to use `DEVNET_NODE_URL` instead of `TESTNET_NODE_URL`
- Once a testnet endpoint is available, a new PR will be created to add the new network to the scripts and `TESTNET_NODE_URL` will be updated in the repository settings

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

N/A

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
