### PR TITLE
wip: refactor hash to a fixed byte array

### DIFF
--- a/packages/common/src/msg.rs
+++ b/packages/common/src/msg.rs
@@ -26,7 +26,7 @@ pub enum DataRequestsExecuteMsg {
     },
     CommitDataResult {
         dr_id: Hash,
-        commitment: String,
+        commitment: Hash,
         sender: Option<String>,
     },
     RevealDataResult {

--- a/packages/common/src/types.rs
+++ b/packages/common/src/types.rs
@@ -1,4 +1,4 @@
 pub type Bytes = Vec<u8>;
 pub type Commitment = Hash;
 pub type Memo = Vec<u8>;
-pub type Hash = String;
+pub type Hash = [u8; 32];

--- a/packages/data-requests/src/data_request_result.rs
+++ b/packages/data-requests/src/data_request_result.rs
@@ -20,6 +20,7 @@ pub mod data_request_results {
     use common::types::Bytes;
 
     use crate::contract::CONTRACT_VERSION;
+    use crate::utils::hash_to_string;
     use crate::{
         state::DATA_RESULTS,
         utils::{check_eligibility, hash_data_result, validate_sender},
@@ -58,9 +59,9 @@ pub mod data_request_results {
             .add_attribute("action", "commit_data_result")
             .add_event(Event::new("seda-commitment").add_attributes([
                 ("version", CONTRACT_VERSION),
-                ("dr_id", dr_id.as_str()),
+                ("dr_id", &hash_to_string(dr_id)),
                 ("executor", sender.as_str()),
-                ("commitment", commitment.as_str()),
+                ("commitment", &hash_to_string(commitment)),
             ])))
     }
 
@@ -111,7 +112,7 @@ pub mod data_request_results {
             .add_attribute("action", "reveal_data_result")
             .add_event(Event::new("seda-reveal").add_attributes([
                 ("version", CONTRACT_VERSION),
-                ("dr_id", dr_id.as_str()),
+                ("dr_id", &hash_to_string(dr_id)),
                 ("executor", sender.as_str()),
                 ("reveal", serde_json::to_string(&reveal).unwrap().as_str()),
             ]));
@@ -140,8 +141,8 @@ pub mod data_request_results {
 
             response = response.add_event(Event::new("seda-data-result").add_attributes([
                 ("version", CONTRACT_VERSION),
-                ("result_id", &result_id),
-                ("dr_id", &dr_id),
+                ("result_id", &hash_to_string(result_id)),
+                ("dr_id", &hash_to_string(dr_id)),
                 ("block_height", &block_height.to_string()),
                 ("exit_code", &exit_code.to_string()),
                 ("result", &serde_json::to_string(&result).unwrap()),
@@ -250,11 +251,11 @@ pub mod data_request_results {
 
     /// Returns a vector of revealed data requests ids, if it exists.
 
-    fn compute_hash(reveal: &str, salt: &str) -> String {
+    fn compute_hash(reveal: &str, salt: &str) -> Hash {
         let mut hasher = Keccak256::new();
         hasher.update(reveal.as_bytes());
         hasher.update(salt.as_bytes());
-        let digest = hasher.finalize();
-        format!("0x{}", hex::encode(digest))
+        // format!("0x{}", hex::encode(hasher.finalize()))
+        hasher.finalize().into()
     }
 }

--- a/packages/data-requests/src/error.rs
+++ b/packages/data-requests/src/error.rs
@@ -10,7 +10,7 @@ pub enum ContractError {
     NoFunds,
     #[error("Insufficient funds. Required: {0}, available: {1}")]
     InsufficientFunds(u128, u128),
-    #[error("Invalid data request id, expected: {0}, actual: {1}")]
+    #[error("Invalid data request id, expected: {0:#?}, actual: {1:#?}")]
     InvalidDataRequestId(Hash, Hash),
     #[error("Data request already exists")]
     DataRequestAlreadyExists,

--- a/packages/proxy/src/msg.rs
+++ b/packages/proxy/src/msg.rs
@@ -25,7 +25,7 @@ pub enum ProxyExecuteMsg {
 
     // DataRequests
     PostDataRequest { posted_dr: PostDataRequestArgs },
-    CommitDataResult { dr_id: Hash, commitment: String },
+    CommitDataResult { dr_id: Hash, commitment: Hash },
     RevealDataResult { dr_id: Hash, reveal: Reveal },
     // Staking
     RegisterDataRequestExecutor { p2p_multi_address: Option<String> },


### PR DESCRIPTION
 Refactors `Hash` into a fixed array byte instead of a String.
Closes https://github.com/sedaprotocol/seda-chain-contracts/issues/65