### PR TITLE
chore: use environment secrets and chain id in deploy scripts

### DIFF
--- a/.github/workflows/Deploy-All.yml
+++ b/.github/workflows/Deploy-All.yml
@@ -5,6 +5,7 @@ on:
         type: choice
         options:
           - devnet
+          - testnet
       password:
         required: true
 
@@ -30,16 +31,17 @@ jobs:
     needs: [check_pass]
     if: ${{ needs.check_pass.outputs.is_allowed == 'true' }}
     name: Deploy
+    environment:
+      name: ${{ github.event.inputs.network }}
     runs-on: ubuntu-latest
     steps:
       - name: Set Environment Variables
         run: |
-          case "${{ github.event.inputs.network }}" in
-            devnet)
-              echo "Setting NODE_URL for devnet"
-              echo "NODE_URL=${{ secrets.TESTNET_NODE_URL }}" >> $GITHUB_ENV
-              ;;
-          esac
+          echo "Setting environment variables for network"
+          echo "NODE_URL=${{ secrets.NODE_URL }}" >> $GITHUB_ENV
+          echo "DEV_ACCOUNT=${{ secrets.DEV_ACCOUNT }}" >> $GITHUB_ENV
+          echo "KEYRING_FILE_ID=${{ secrets.KEYRING_FILE_ID }}" >> $GITHUB_ENV
+          echo "CHAIN_ID=seda-${{ github.event.inputs.network }}" >> $GITHUB_ENV
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -72,7 +74,7 @@ jobs:
       - name: Download and decrypt keys
         env:
           KEYRING_PASSWORD: ${{ secrets.KEYRING_PASSWORD }}
-          KEYRING_FILE_ID: ${{ secrets.KEYRING_FILE_ID }}
+          KEYRING_FILE_ID: ${{ env.KEYRING_FILE_ID }}
         run: |
           keyringFileId=${{ env.KEYRING_FILE_ID }}
           keyringFileName=keyring.tar.gz.enc
@@ -86,12 +88,14 @@ jobs:
 
       - name: Store Proxy on chain
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: store-proxy
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/proxy_contract.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/proxy_contract.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --chain-id=${chainId} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
           TXHASH=$(echo $OUTPUT | jq -r '.txhash')
           echo "Store transaction is $TXHASH"
           echo "proxy_store_tx_hash=$TXHASH" >> $GITHUB_ENV
@@ -110,12 +114,14 @@ jobs:
 
       - name: Instantiate Proxy
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: instantiate-proxy
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.proxy_code_id }} '{"token":"aseda"}' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --label proxy${{ env.proxy_code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.proxy_code_id }} '{"token":"aseda"}' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --label proxy${{ env.proxy_code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
           TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
           echo "Instantiate transaction is $TXHASH"
           echo "proxy_instantiate_tx_hash=$TXHASH" >> $GITHUB_ENV
@@ -135,12 +141,14 @@ jobs:
 
       - name: Store DataRequests on chain
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: store-dr
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/data_requests.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/data_requests.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --chain-id=${chainId} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
           TXHASH=$(echo $OUTPUT | jq -r '.txhash')
           echo "Store transaction is $TXHASH"
           echo "dr_store_tx_hash=$TXHASH" >> $GITHUB_ENV
@@ -159,12 +167,14 @@ jobs:
 
       - name: Instantiate DataRequests
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: instantiate-dr
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.dr_code_id }} '{"token":"aseda", "proxy": ${{ toJSON(env.proxy_address) }} }' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --label dr${{ env.dr_code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.dr_code_id }} '{"token":"aseda", "proxy": ${{ toJSON(env.proxy_address) }} }' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --label dr${{ env.dr_code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
           TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
           echo "Instantiate transaction is $TXHASH"
           echo "dr_instantiate_tx_hash=$TXHASH" >> $GITHUB_ENV
@@ -184,12 +194,14 @@ jobs:
 
       - name: Store Staking on chain
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: store-staking
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/staking.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/staking.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --chain-id=${chainId} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
           TXHASH=$(echo $OUTPUT | jq -r '.txhash')
           echo "Store transaction is $TXHASH"
           echo "staking_store_tx_hash=$TXHASH" >> $GITHUB_ENV
@@ -208,12 +220,14 @@ jobs:
 
       - name: Instantiate Staking
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: instantiate-staking
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.staking_code_id }} '{"token":"aseda", "proxy": ${{ toJSON(env.proxy_address) }} }' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --label staking${{ env.staking_code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.staking_code_id }} '{"token":"aseda", "proxy": ${{ toJSON(env.proxy_address) }} }' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --label staking${{ env.staking_code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
           TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
           echo "Instantiate transaction is $TXHASH"
           echo "staking_instantiate_tx_hash=$TXHASH" >> $GITHUB_ENV
@@ -234,7 +248,8 @@ jobs:
       - name: Set DataRequests on Proxy
         run: |
           nodeUrl=${{ env.NODE_URL }}
-          OUTPUT="$(./seda-chaind tx wasm execute ${{ env.proxy_address }} '{"set_data_requests":{"contract": ${{ toJSON(env.dr_address) }} }}' --from ${{ secrets.DEV_ACCOUNT }} --node ${nodeUrl} --keyring-dir . --keyring-backend test --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT="$(./seda-chaind tx wasm execute ${{ env.proxy_address }} '{"set_data_requests":{"contract": ${{ toJSON(env.dr_address) }} }}' --from ${{ env.DEV_ACCOUNT }} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
           TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
           echo "SetDataRequests transaction is $TXHASH"
 
@@ -244,7 +259,8 @@ jobs:
       - name: Set Staking on Proxy
         run: |
           nodeUrl=${{ env.NODE_URL }}
-          OUTPUT="$(./seda-chaind tx wasm execute ${{ env.proxy_address }} '{"set_staking":{"contract": ${{ toJSON(env.staking_address) }} }}' --from ${{ secrets.DEV_ACCOUNT }} --node ${nodeUrl} --keyring-dir . --keyring-backend test --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT="$(./seda-chaind tx wasm execute ${{ env.proxy_address }} '{"set_staking":{"contract": ${{ toJSON(env.staking_address) }} }}' --from ${{ env.DEV_ACCOUNT }} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
           TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
           echo "SetStaking transaction is $TXHASH"
 

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -5,6 +5,7 @@ on:
         type: choice
         options:
           - devnet
+          - testnet
       contract:
         type: choice
         options:
@@ -52,6 +53,8 @@ jobs:
     needs: [check_pass, check_proxy]
     if: ${{ needs.check_pass.outputs.is_allowed == 'true' && needs.check_proxy.outputs.proxy_ok == 'true' }}
     name: Deploy
+    environment:
+      name: ${{ github.event.inputs.network }}
     runs-on: ubuntu-latest
     steps:
       - name: Output Contract Name
@@ -60,12 +63,10 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          case "${{ github.event.inputs.network }}" in
-            devnet)
-              echo "Setting NODE_URL for devnet"
-              echo "NODE_URL=${{ secrets.TESTNET_NODE_URL }}" >> $GITHUB_ENV
-              ;;
-          esac
+          echo "NODE_URL=${{ secrets.NODE_URL }}" >> $GITHUB_ENV
+          echo "DEV_ACCOUNT=${{ secrets.DEV_ACCOUNT }}" >> $GITHUB_ENV
+          echo "KEYRING_FILE_ID=${{ secrets.KEYRING_FILE_ID }}" >> $GITHUB_ENV
+          echo "CHAIN_ID=seda-${{ github.event.inputs.network }}" >> $GITHUB_ENV
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -98,7 +99,7 @@ jobs:
       - name: Download and decrypt keys
         env:
           KEYRING_PASSWORD: ${{ secrets.KEYRING_PASSWORD }}
-          KEYRING_FILE_ID: ${{ secrets.KEYRING_FILE_ID }}
+          KEYRING_FILE_ID: ${{ env.KEYRING_FILE_ID }}
         run: |
           keyringFileId=${{ env.KEYRING_FILE_ID }}
           keyringFileName=keyring.tar.gz.enc
@@ -110,12 +111,14 @@ jobs:
 
       - name: Store contract on chain
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: store
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
-          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/${{ github.event.inputs.contract }}.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
+          chainId=${{ env.CHAIN_ID }}
+          OUTPUT="$(./seda-chaind tx wasm store ./artifacts/${{ github.event.inputs.contract }}.wasm --node ${nodeUrl} --from ${devAccount} --keyring-dir . --keyring-backend test --chain-id=${chainId} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)"
           TXHASH=$(echo $OUTPUT | jq -r '.txhash')
           echo "Store transaction is $TXHASH"
           echo "txhash=$TXHASH" >> $GITHUB_ENV
@@ -134,16 +137,18 @@ jobs:
 
       - name: Instantiate contract
         env:
-          DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+          DEV_ACCOUNT: ${{ env.DEV_ACCOUNT }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
         id: instantiate
         run: |
           nodeUrl=${{ env.NODE_URL }}
           devAccount=${{ env.DEV_ACCOUNT }}
+          chainId=${{ env.CHAIN_ID }}
           if [[ "${{ github.event.inputs.contract }}" != "proxy_contract" ]]; then
             proxy=${{ github.event.inputs.proxy }}
-            OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.code_id }} '{"token":"aseda", "proxy": ${{ toJSON(github.event.inputs.proxy) }} }' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --label ${{ env.code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
+            OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.code_id }} '{"token":"aseda", "proxy": ${{ toJSON(github.event.inputs.proxy) }} }' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --label ${{ env.code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
           else
-            OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.code_id }} '{"token":"aseda"}' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --label ${{ env.code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
+            OUTPUT=$(./seda-chaind tx wasm instantiate ${{ env.code_id }} '{"token":"aseda"}' --no-admin --from ${devAccount} --node ${nodeUrl} --keyring-dir . --keyring-backend test --chain-id=${chainId} --label ${{ env.code_id }} --gas-prices 0.1aseda --gas auto --gas-adjustment 1.3 -y --output json)
           fi
           TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
           echo "Instantiate transaction is $TXHASH"


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Add new network option to scripts to deploy to testnet, as well as update 

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Uploaded updated keys for deploying contracts to Google Drive for both devnet and testnet (while testing I attempted to use environment secrets to import the keys, but I kept getting an invalid base64 error. I created an issue here to update this: https://github.com/sedaprotocol/seda-chain-contracts/issues/93 )
- Added `testnet` to network selector and set environment variables based on corresponding environment secrets for each network.
- Pass `chain-id` as an argument to `seda-chaind` to fix commands.
- Updated actions secrets and environment secrets for this repository for compatibility with this PR. No need to worry about breaking the current scripts since they currently don't work as-is.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested manually on a fork of this repo. Since I don't have access to GH environments on a private repo, I manually set `NODE_URL`, `DEV_ACCOUNT`, and `KEYRING_FILE_ID` for both devnet and testnet when testing each.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

