### PR TITLE
🔧 In CI scripts download/use `seda-chaind` binary from release page

### DIFF
--- a/.github/workflows/Deploy-All.yml
+++ b/.github/workflows/Deploy-All.yml
@@ -60,17 +60,15 @@ jobs:
           --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
           cosmwasm/rust-optimizer:0.12.11
 
-      - name: Download seda-chaind binary and make executable
-        env:
-          SEDACHAIND_FILE_ID: ${{ secrets.SEDACHAIND_FILE_ID }}
+      - name: Download seda-chaind binary
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo: sedaprotocol/seda-chain
+
+      - name: Move seda-chaind to current directory
         run: |
-          sedachaindFileId=${{ env.SEDACHAIND_FILE_ID }}
-          sedachaindFileName=seda-chaind-x86-64.tar.gz
-          curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=${sedachaindFileId}" > /dev/null
-          code="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-          curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${code}&id=${sedachaindFileId}" -o ${sedachaindFileName}
-          tar -xvf seda-chaind-x86-64.tar.gz
-          chmod +x seda-chaind
+          cp /opt/hostedtoolcache/sedaprotocol/seda-chain/latest/linux-x64/seda-chaind .
 
       - name: Import key
         env:

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -85,17 +85,15 @@ jobs:
           --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
           cosmwasm/rust-optimizer:0.12.11
 
-      - name: Download seda-chaind binary and make executable
-        env:
-          SEDACHAIND_FILE_ID: ${{ secrets.SEDACHAIND_FILE_ID }}
+      - name: Download seda-chaind binary
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repo: sedaprotocol/seda-chain
+
+      - name: Move seda-chaind to current directory
         run: |
-          sedachaindFileId=${{ env.SEDACHAIND_FILE_ID }}
-          sedachaindFileName=seda-chaind-x86-64.tar.gz
-          curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=${sedachaindFileId}" > /dev/null
-          code="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-          curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${code}&id=${sedachaindFileId}" -o ${sedachaindFileName}
-          tar -xvf seda-chaind-x86-64.tar.gz
-          chmod +x seda-chaind
+          cp /opt/hostedtoolcache/sedaprotocol/seda-chain/latest/linux-x64/seda-chaind .
 
       - name: Import key
         env:


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Less work to maintain the latest version of the `seda-chaind` binary. Remove dependency on Google Drive.

## Explanation of Changes

Added new github secret to this repository `PERSONAL_ACCESS_TOKEN` to download `seda-chaind` binary from `sedaprotocol/seda-chaind` repo, replacing download from Google Drive.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested on a private fork of this repo.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #92
