### PR TITLE
Add optional allowlist for registering data request executors managed by owner

### DIFF
--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -20,6 +20,8 @@ pub enum ContractError {
     NotPendingOwner,
     #[error("NoPendingOwnerFound: No pending owner found")]
     NoPendingOwnerFound,
+    #[error("NotOnAllowlist: Address is not on the allowlist")]
+    NotOnAllowlist,
 
     // DR contract errors
     #[error("InsufficientFunds: Insufficient funds. Required: {0}, available: {1}")]

--- a/packages/common/src/msg.rs
+++ b/packages/common/src/msg.rs
@@ -43,7 +43,7 @@ pub enum DataRequestsExecuteMsg {
 #[cw_serde]
 pub enum StakingExecuteMsg {
     RegisterDataRequestExecutor {
-        p2p_multi_address: Option<String>,
+        memo: Option<String>,
         sender: Option<String>,
     },
     UnregisterDataRequestExecutor {
@@ -66,6 +66,14 @@ pub enum StakingExecuteMsg {
     AcceptOwnership {},
     SetStakingConfig {
         config: StakingConfig,
+    },
+    AddToAllowlist {
+        sender: Option<String>,
+        address: Addr,
+    },
+    RemoveFromAllowlist {
+        sender: Option<String>,
+        address: Addr,
     },
 }
 

--- a/packages/common/src/state.rs
+++ b/packages/common/src/state.rs
@@ -79,7 +79,7 @@ pub struct Reveal {
 /// A data request executor with staking info and optional p2p multi address
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, JsonSchema)]
 pub struct DataRequestExecutor {
-    pub p2p_multi_address: Option<String>,
+    pub memo: Option<String>,
     pub tokens_staked: u128,
     pub tokens_pending_withdrawal: u128,
 }
@@ -91,4 +91,6 @@ pub struct StakingConfig {
     pub minimum_stake_to_register: u128,
     /// Minimum amount of SEDA tokens required to be eligible for committee inclusion
     pub minimum_stake_for_committee_eligibility: u128,
+    /// Whether the allowlist is enabled
+    pub allowlist_enabled: bool,
 }

--- a/packages/integration-tests/src/data_result.rs
+++ b/packages/integration-tests/src/data_result.rs
@@ -34,7 +34,7 @@ fn commit_reveal_result() {
     send_tokens(&mut app, USER, EXECUTOR_2, 1);
     send_tokens(&mut app, USER, EXECUTOR_3, 1);
     let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
-        p2p_multi_address: Some("address".to_string()),
+        memo: Some("address".to_string()),
     };
     let cosmos_msg = proxy_contract
         .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
@@ -286,7 +286,7 @@ fn pop_and_swap_in_pool() {
     send_tokens(&mut app, USER, EXECUTOR_1, 1);
     send_tokens(&mut app, USER, EXECUTOR_2, 1);
     let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
-        p2p_multi_address: Some("address".to_string()),
+        memo: Some("address".to_string()),
     };
     let cosmos_msg = proxy_contract
         .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)

--- a/packages/integration-tests/src/staking.rs
+++ b/packages/integration-tests/src/staking.rs
@@ -15,7 +15,7 @@ fn deposit_stake_withdraw() {
     send_tokens(&mut app, USER, EXECUTOR_1, 3);
 
     let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
-        p2p_multi_address: Some("address".to_string()),
+        memo: Some("address".to_string()),
     };
     let cosmos_msg = proxy_contract
         .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
@@ -36,7 +36,7 @@ fn deposit_stake_withdraw() {
         res,
         GetDataRequestExecutorResponse {
             value: Some(DataRequestExecutor {
-                p2p_multi_address: Some("address".to_string()),
+                memo: Some("address".to_string()),
                 tokens_staked: 1,
                 tokens_pending_withdrawal: 0
             })
@@ -61,7 +61,7 @@ fn deposit_stake_withdraw() {
         res,
         GetDataRequestExecutorResponse {
             value: Some(DataRequestExecutor {
-                p2p_multi_address: Some("address".to_string()),
+                memo: Some("address".to_string()),
                 tokens_staked: 3,
                 tokens_pending_withdrawal: 0
             })
@@ -86,7 +86,7 @@ fn deposit_stake_withdraw() {
         res,
         GetDataRequestExecutorResponse {
             value: Some(DataRequestExecutor {
-                p2p_multi_address: Some("address".to_string()),
+                memo: Some("address".to_string()),
                 tokens_staked: 1,
                 tokens_pending_withdrawal: 2
             })
@@ -119,7 +119,7 @@ fn deposit_stake_withdraw() {
         res,
         GetDataRequestExecutorResponse {
             value: Some(DataRequestExecutor {
-                p2p_multi_address: Some("address".to_string()),
+                memo: Some("address".to_string()),
                 tokens_staked: 1,
                 tokens_pending_withdrawal: 0
             })

--- a/packages/proxy/src/contract.rs
+++ b/packages/proxy/src/contract.rs
@@ -130,7 +130,7 @@ pub fn execute(
             .add_attribute("action", "reveal_data_result")),
 
         // Staking
-        ProxyExecuteMsg::RegisterDataRequestExecutor { p2p_multi_address } => {
+        ProxyExecuteMsg::RegisterDataRequestExecutor { memo } => {
             // require token deposit
             let token = TOKEN.load(deps.storage)?;
             let amount = get_attached_funds(&info.funds, &token)?;
@@ -139,7 +139,7 @@ pub fn execute(
                 .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: STAKING.load(deps.storage)?.to_string(),
                     msg: to_json_binary(&StakingExecuteMsg::RegisterDataRequestExecutor {
-                        p2p_multi_address,
+                        memo,
                         sender: Some(info.sender.to_string()),
                     })?,
                     funds: vec![Coin {
@@ -196,6 +196,26 @@ pub fn execute(
                 funds: vec![],
             }))
             .add_attribute("action", "withdraw")),
+        ProxyExecuteMsg::AddToAllowlist { address } => Ok(Response::new()
+            .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: STAKING.load(deps.storage)?.to_string(),
+                msg: to_json_binary(&StakingExecuteMsg::AddToAllowlist {
+                    sender: Some(info.sender.to_string()),
+                    address,
+                })?,
+                funds: vec![],
+            }))
+            .add_attribute("action", "add_to_allowlist")),
+        ProxyExecuteMsg::RemoveFromAllowlist { address } => Ok(Response::new()
+            .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: STAKING.load(deps.storage)?.to_string(),
+                msg: to_json_binary(&StakingExecuteMsg::RemoveFromAllowlist {
+                    sender: Some(info.sender.to_string()),
+                    address,
+                })?,
+                funds: vec![],
+            }))
+            .add_attribute("action", "remove_from_allowlist")),
     }
 }
 

--- a/packages/proxy/src/msg.rs
+++ b/packages/proxy/src/msg.rs
@@ -32,11 +32,13 @@ pub enum ProxyExecuteMsg {
     CommitDataResult { dr_id: Hash, commitment: Hash },
     RevealDataResult { dr_id: Hash, reveal: Reveal },
     // Staking
-    RegisterDataRequestExecutor { p2p_multi_address: Option<String> },
+    RegisterDataRequestExecutor { memo: Option<String> },
     UnregisterDataRequestExecutor {},
     DepositAndStake,
     Unstake { amount: u128 },
     Withdraw { amount: u128 },
+    AddToAllowlist { address: Addr },
+    RemoveFromAllowlist { address: Addr },
 }
 
 #[cw_serde]

--- a/packages/staking/src/allowlist.rs
+++ b/packages/staking/src/allowlist.rs
@@ -1,0 +1,131 @@
+pub mod allow_list {
+    use crate::state::{ALLOWLIST, OWNER};
+    use crate::utils::validate_sender;
+    use common::error::ContractError;
+    #[cfg(not(feature = "library"))]
+    use cosmwasm_std::{Addr, DepsMut, MessageInfo, Response};
+
+    pub fn add_to_allowlist(
+        deps: DepsMut,
+        info: MessageInfo,
+        sender: Option<String>,
+        address: Addr,
+    ) -> Result<Response, ContractError> {
+        let sender = validate_sender(&deps, info.sender, sender)?;
+
+        // require the sender to be the OWNER
+        let owner = OWNER.load(deps.storage)?;
+        if sender != owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        // add the address to the allowlist
+        ALLOWLIST.save(deps.storage, address, &true)?;
+
+        Ok(Response::new())
+    }
+
+    pub fn remove_from_allowlist(
+        deps: DepsMut,
+        info: MessageInfo,
+        sender: Option<String>,
+        address: Addr,
+    ) -> Result<Response, ContractError> {
+        let sender = validate_sender(&deps, info.sender, sender)?;
+
+        // require the sender to be the OWNER
+        let owner = OWNER.load(deps.storage)?;
+        if sender != owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        // remove the address from the allowlist
+        ALLOWLIST.remove(deps.storage, address);
+
+        Ok(Response::new())
+    }
+}
+
+#[cfg(test)]
+mod executers_tests {
+    use crate::helpers::helper_add_to_allowlist;
+    use crate::helpers::helper_register_executor;
+    use crate::helpers::helper_remove_from_allowlist;
+    use crate::helpers::helper_set_staking_config;
+    use crate::helpers::helper_unregister_executor;
+    use crate::helpers::helper_unstake;
+    use crate::helpers::helper_withdraw;
+    use crate::helpers::instantiate_staking_contract;
+    use common::error::ContractError;
+    use common::state::StakingConfig;
+    use cosmwasm_std::coins;
+    use cosmwasm_std::testing::{mock_dependencies, mock_info};
+
+    #[test]
+    pub fn allowlist_works() {
+        let mut deps = mock_dependencies();
+
+        let info = mock_info("creator", &coins(2, "token"));
+        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
+
+        // update the config with allowlist enabled
+        let info = mock_info("owner", &coins(0, "token"));
+        let new_config = StakingConfig {
+            minimum_stake_to_register: 100,
+            minimum_stake_for_committee_eligibility: 200,
+            allowlist_enabled: true,
+        };
+        let res = helper_set_staking_config(deps.as_mut(), info, new_config);
+        assert!(res.is_ok());
+
+        // alice tries to register a data request executor, but she's not on the allowlist
+        let info = mock_info("alice", &coins(100, "token"));
+        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
+        assert_eq!(res.is_err_and(|x| x == ContractError::NotOnAllowlist), true);
+
+        // add alice to the allowlist
+        let info = mock_info("owner", &coins(0, "token"));
+        let res = helper_add_to_allowlist(deps.as_mut(), info, "alice".to_string(), None);
+        assert!(res.is_ok());
+
+        // now alice can register a data request executor
+        let info = mock_info("alice", &coins(100, "token"));
+        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
+        assert!(res.is_ok());
+
+        // alice unstakes, withdraws, then unregisters herself
+        let info = mock_info("alice", &coins(0, "token"));
+        let _res = helper_unstake(deps.as_mut(), info.clone(), 100, None);
+        let info = mock_info("alice", &coins(0, "token"));
+        let _res = helper_withdraw(deps.as_mut(), info.clone(), 100, None);
+        let info = mock_info("alice", &coins(0, "token"));
+        let res = helper_unregister_executor(deps.as_mut(), info, None);
+        println!("{:?}", res);
+        assert!(res.is_ok());
+
+        // remove alice from the allowlist
+        let info = mock_info("owner", &coins(0, "token"));
+        let res = helper_remove_from_allowlist(deps.as_mut(), info, "alice".to_string(), None);
+        assert!(res.is_ok());
+
+        // now alice can't register a data request executor
+        let info = mock_info("alice", &coins(2, "token"));
+        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
+        assert_eq!(res.is_err_and(|x| x == ContractError::NotOnAllowlist), true);
+
+        // update the config to disable the allowlist
+        let info = mock_info("owner", &coins(0, "token"));
+        let new_config = StakingConfig {
+            minimum_stake_to_register: 100,
+            minimum_stake_for_committee_eligibility: 200,
+            allowlist_enabled: false,
+        };
+        let res = helper_set_staking_config(deps.as_mut(), info, new_config);
+        assert!(res.is_ok());
+
+        // now alice can register a data request executor
+        let info = mock_info("alice", &coins(100, "token"));
+        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
+        assert!(res.is_ok());
+    }
+}

--- a/packages/staking/src/helpers.rs
+++ b/packages/staking/src/helpers.rs
@@ -25,13 +25,10 @@ pub fn instantiate_staking_contract(
 pub fn helper_register_executor(
     deps: DepsMut,
     info: MessageInfo,
-    p2p_multi_address: Option<String>,
+    memo: Option<String>,
     sender: Option<String>,
 ) -> Result<Response, ContractError> {
-    let msg = StakingExecuteMsg::RegisterDataRequestExecutor {
-        p2p_multi_address,
-        sender,
-    };
+    let msg = StakingExecuteMsg::RegisterDataRequestExecutor { memo, sender };
     execute(deps, mock_env(), info, msg)
 }
 
@@ -120,5 +117,31 @@ pub fn helper_set_staking_config(
     config: StakingConfig,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::SetStakingConfig { config };
+    execute(deps, mock_env(), info, msg)
+}
+
+pub fn helper_add_to_allowlist(
+    deps: DepsMut,
+    info: MessageInfo,
+    address: String,
+    sender: Option<String>,
+) -> Result<Response, ContractError> {
+    let msg = StakingExecuteMsg::AddToAllowlist {
+        address: Addr::unchecked(address),
+        sender,
+    };
+    execute(deps, mock_env(), info, msg)
+}
+
+pub fn helper_remove_from_allowlist(
+    deps: DepsMut,
+    info: MessageInfo,
+    address: String,
+    sender: Option<String>,
+) -> Result<Response, ContractError> {
+    let msg = StakingExecuteMsg::RemoveFromAllowlist {
+        address: Addr::unchecked(address),
+        sender,
+    };
     execute(deps, mock_env(), info, msg)
 }

--- a/packages/staking/src/lib.rs
+++ b/packages/staking/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod allowlist;
 pub mod contract;
 pub mod executors_registry;
 pub mod staking;

--- a/packages/staking/src/staking.rs
+++ b/packages/staking/src/staking.rs
@@ -44,10 +44,7 @@ pub mod staking {
                 Event::new("seda-data-request-executor").add_attributes([
                     ("version", CONTRACT_VERSION),
                     ("executor", sender.as_ref()),
-                    (
-                        "p2p_multi_address",
-                        &executor.p2p_multi_address.unwrap_or_default(),
-                    ),
+                    ("memo", &executor.memo.unwrap_or_default()),
                     ("tokens_staked", &executor.tokens_staked.to_string()),
                     (
                         "tokens_pending_withdrawal",
@@ -95,10 +92,7 @@ pub mod staking {
                 Event::new("seda-data-request-executor").add_attributes([
                     ("version", CONTRACT_VERSION),
                     ("executor", sender.as_ref()),
-                    (
-                        "p2p_multi_address",
-                        &executor.p2p_multi_address.unwrap_or_default(),
-                    ),
+                    ("memo", &executor.memo.unwrap_or_default()),
                     ("tokens_staked", &executor.tokens_staked.to_string()),
                     (
                         "tokens_pending_withdrawal",
@@ -152,10 +146,7 @@ pub mod staking {
                 Event::new("seda-data-request-executor").add_attributes([
                     ("version", CONTRACT_VERSION),
                     ("executor", sender.as_ref()),
-                    (
-                        "p2p_multi_address",
-                        &executor.p2p_multi_address.unwrap_or_default(),
-                    ),
+                    ("memo", &executor.memo.unwrap_or_default()),
                     ("tokens_staked", &executor.tokens_staked.to_string()),
                     (
                         "tokens_pending_withdrawal",
@@ -292,7 +283,7 @@ mod staking_tests {
             value,
             GetDataRequestExecutorResponse {
                 value: Some(DataRequestExecutor {
-                    p2p_multi_address: Some("address".to_string()),
+                    memo: Some("address".to_string()),
                     tokens_staked: 1,
                     tokens_pending_withdrawal: 0
                 })
@@ -314,7 +305,7 @@ mod staking_tests {
             value,
             GetDataRequestExecutorResponse {
                 value: Some(DataRequestExecutor {
-                    p2p_multi_address: Some("address".to_string()),
+                    memo: Some("address".to_string()),
                     tokens_staked: 3,
                     tokens_pending_withdrawal: 0
                 })
@@ -337,7 +328,7 @@ mod staking_tests {
             value,
             GetDataRequestExecutorResponse {
                 value: Some(DataRequestExecutor {
-                    p2p_multi_address: Some("address".to_string()),
+                    memo: Some("address".to_string()),
                     tokens_staked: 2,
                     tokens_pending_withdrawal: 1
                 })
@@ -361,7 +352,7 @@ mod staking_tests {
             value,
             GetDataRequestExecutorResponse {
                 value: Some(DataRequestExecutor {
-                    p2p_multi_address: Some("address".to_string()),
+                    memo: Some("address".to_string()),
                     tokens_staked: 2,
                     tokens_pending_withdrawal: 0
                 })
@@ -406,7 +397,7 @@ mod staking_tests {
         // register a data request executor
         let info = mock_info("anyone", &coins(1, "token"));
         let msg = ExecuteMsg::RegisterDataRequestExecutor {
-            p2p_multi_address: Some("address".to_string()),
+            memo: Some("address".to_string()),
             sender: None,
         };
         execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/packages/staking/src/state.rs
+++ b/packages/staking/src/state.rs
@@ -24,3 +24,6 @@ pub const PENDING_OWNER: Item<Option<Addr>> = Item::new("pending_owner");
 
 /// Governance-controlled configuration parameters
 pub const CONFIG: Item<StakingConfig> = Item::new("config");
+
+/// Allowlist of addresses that can register as a data request executor
+pub const ALLOWLIST: Map<Addr, bool> = Map::new("allowlist");


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This is a temporary feature until secret random committees are implemented.

## Explanation of Changes

Kept it pretty minimal:
- renamed DRE property `p2p_multi_address` to `memo`
- added state variable `ALLOWLIST` (mapping of address->bool) and new config property `allowlist_enabled` (set to false at contract instantiation)
- add allowlist check only on registering data request executor
- new execute messages `AddToAllowlist` and `RemoveFromAllowlist`

Any other suggestions welcome (I wasn't sure how polished to take this), e.g.:
- Pass a list of addresses to add and remove from the allowlist instead of one at a time
- Query functions for who is on the allowlist
- ability to iterate over the allowlist?
- whether to enable allowlist by default?
- Add allowlist check to other staking functions?

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Created a unit test in `packages/staking/src/allowlist.rs`

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #123