### PR TITLE
refactor: force execute calls to originate from proxy

### DIFF
--- a/fuzz/fuzz_targets/proxy_instantiate.rs
+++ b/fuzz/fuzz_targets/proxy_instantiate.rs
@@ -3,7 +3,7 @@
 use cosmwasm_std::{Addr, Coin, Empty, Uint128};
 use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor};
 use libfuzzer_sys::fuzz_target;
-use proxy_contract::msg::InstantiateMsg;
+use proxy_contract::msg::ProxyInstantiateMsg;
 
 const ADMIN: &str = "admin";
 pub const NATIVE_DENOM: &str = "seda";
@@ -41,7 +41,7 @@ fn proxy_contract_template() -> Box<dyn Contract<Empty>> {
     Box::new(contract)
 }
 
-fuzz_target!(|msg: InstantiateMsg| {
+fuzz_target!(|msg: ProxyInstantiateMsg| {
     // fuzzed code goes here
     let mut app = mock_app();
 

--- a/packages/common/src/msg.rs
+++ b/packages/common/src/msg.rs
@@ -31,12 +31,12 @@ pub enum DataRequestsExecuteMsg {
     CommitDataResult {
         dr_id: Hash,
         commitment: Hash,
-        sender: Option<String>,
+        sender: String,
     },
     RevealDataResult {
         dr_id: Hash,
         reveal: Reveal,
-        sender: Option<String>,
+        sender: String,
     },
 }
 
@@ -44,21 +44,21 @@ pub enum DataRequestsExecuteMsg {
 pub enum StakingExecuteMsg {
     RegisterDataRequestExecutor {
         memo: Option<String>,
-        sender: Option<String>,
+        sender: String,
     },
     UnregisterDataRequestExecutor {
-        sender: Option<String>,
+        sender: String,
     },
     DepositAndStake {
-        sender: Option<String>,
+        sender: String,
     },
     Unstake {
         amount: u128,
-        sender: Option<String>,
+        sender: String,
     },
     Withdraw {
         amount: u128,
-        sender: Option<String>,
+        sender: String,
     },
     TransferOwnership {
         new_owner: String,
@@ -68,11 +68,11 @@ pub enum StakingExecuteMsg {
         config: StakingConfig,
     },
     AddToAllowlist {
-        sender: Option<String>,
+        sender: String,
         address: Addr,
     },
     RemoveFromAllowlist {
-        sender: Option<String>,
+        sender: String,
         address: Addr,
     },
 }

--- a/packages/data-requests/src/utils.rs
+++ b/packages/data-requests/src/utils.rs
@@ -65,18 +65,11 @@ pub fn hash_data_result(
     hasher.finalize().into()
 }
 
-pub fn validate_sender(
-    deps: &DepsMut,
-    caller: Addr,
-    sender: Option<String>,
-) -> Result<Addr, ContractError> {
-    // if a sender is passed, caller must be the proxy contract
-    match sender {
-        Some(_sender) if caller != PROXY_CONTRACT.load(deps.storage)? => {
-            Err(ContractError::NotProxy {})
-        }
-        Some(sender) => Ok(deps.api.addr_validate(&sender)?),
-        None => Ok(caller),
+pub fn caller_is_proxy(deps: &DepsMut, caller: Addr) -> Result<(), ContractError> {
+    if caller != PROXY_CONTRACT.load(deps.storage)? {
+        Err(ContractError::NotProxy {})
+    } else {
+        Ok(())
     }
 }
 

--- a/packages/integration-tests/src/allowlist.rs
+++ b/packages/integration-tests/src/allowlist.rs
@@ -1,0 +1,188 @@
+use crate::tests::utils::{proper_instantiate, OWNER, USER};
+
+use common::{
+    error::ContractError,
+    msg::{GetDataRequestExecutorResponse, StakingExecuteMsg},
+    state::{DataRequestExecutor, StakingConfig},
+};
+use cosmwasm_std::Addr;
+use cw_multi_test::Executor;
+
+use common::consts::INITIAL_MINIMUM_STAKE_TO_REGISTER;
+use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg};
+
+#[test]
+fn allowlist_works() {
+    let (mut app, proxy_contract, staking_contract) = proper_instantiate();
+
+    // update the config with allowlist enabled
+    let config = StakingConfig {
+        minimum_stake_to_register: 1,
+        minimum_stake_for_committee_eligibility: 200,
+        allowlist_enabled: true,
+    };
+    let msg = StakingExecuteMsg::SetStakingConfig { config };
+    let cosmos_msg = staking_contract.call(msg).unwrap();
+    app.execute(Addr::unchecked(OWNER), cosmos_msg.clone())
+        .unwrap();
+
+    // user tries to register a data request executor, but she's not on the allowlist
+    let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
+        memo: Some("address".to_string()),
+    };
+    let cosmos_msg = proxy_contract
+        .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
+        .unwrap();
+
+    // registering executor should fail
+    let res = app.execute(Addr::unchecked(USER), cosmos_msg.clone());
+
+    assert_eq!(
+        res.is_err_and(|x| {
+            x.source().unwrap().source().unwrap().to_string()
+                == ContractError::NotOnAllowlist.to_string()
+        }),
+        true
+    );
+
+    // add user to allowlist
+    let msg = ProxyExecuteMsg::AddToAllowlist {
+        address: Addr::unchecked(USER),
+    };
+
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+
+    app.execute(Addr::unchecked(OWNER), cosmos_msg.clone())
+        .unwrap();
+
+    // user can now register
+    let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
+        memo: Some("address".to_string()),
+    };
+    let cosmos_msg = proxy_contract
+        .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
+        .unwrap();
+
+    // register executor
+    app.execute(Addr::unchecked(USER), cosmos_msg.clone())
+        .unwrap();
+
+    let msg = ProxyQueryMsg::GetDataRequestExecutor {
+        executor: Addr::unchecked(USER),
+    };
+    let res: GetDataRequestExecutorResponse = app
+        .wrap()
+        .query_wasm_smart(proxy_contract.addr(), &msg)
+        .unwrap();
+
+    assert_eq!(
+        res,
+        GetDataRequestExecutorResponse {
+            value: Some(DataRequestExecutor {
+                memo: Some("address".to_string()),
+                tokens_staked: 1,
+                tokens_pending_withdrawal: 0
+            })
+        }
+    );
+
+    // unstake
+    let msg = ProxyExecuteMsg::Unstake { amount: 1 };
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    app.execute(Addr::unchecked(USER), cosmos_msg.clone())
+        .unwrap();
+
+    // withdraw
+    let msg = ProxyExecuteMsg::Withdraw { amount: 1 };
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    app.execute(Addr::unchecked(USER), cosmos_msg.clone())
+        .unwrap();
+
+    // unregister
+    let msg = ProxyExecuteMsg::UnregisterDataRequestExecutor {};
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    // unregister executor
+    app.execute(Addr::unchecked(USER), cosmos_msg.clone())
+        .unwrap();
+
+    // fetching data request executor for an address that doesn't exist should return None
+    let msg = ProxyQueryMsg::GetDataRequestExecutor {
+        executor: Addr::unchecked("anyone"),
+    };
+
+    let res: GetDataRequestExecutorResponse = app
+        .wrap()
+        .query_wasm_smart(proxy_contract.addr(), &msg)
+        .unwrap();
+
+    assert_eq!(res, GetDataRequestExecutorResponse { value: None });
+
+    // rm user from allowlist
+    let msg = ProxyExecuteMsg::RemoveFromAllowlist {
+        address: Addr::unchecked(USER),
+    };
+
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+
+    app.execute(Addr::unchecked(OWNER), cosmos_msg.clone())
+        .unwrap();
+
+    // registering executor should fail
+    let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
+        memo: Some("address".to_string()),
+    };
+    let cosmos_msg = proxy_contract
+        .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
+        .unwrap();
+
+    let res = app.execute(Addr::unchecked(USER), cosmos_msg.clone());
+    assert_eq!(
+        res.is_err_and(|x| {
+            x.source().unwrap().source().unwrap().to_string()
+                == ContractError::NotOnAllowlist.to_string()
+        }),
+        true
+    );
+
+    // update the config to disable allowlist
+    let config = StakingConfig {
+        minimum_stake_to_register: 1,
+        minimum_stake_for_committee_eligibility: 200,
+        allowlist_enabled: false,
+    };
+    let msg = StakingExecuteMsg::SetStakingConfig { config };
+    let cosmos_msg = staking_contract.call(msg).unwrap();
+    app.execute(Addr::unchecked(OWNER), cosmos_msg.clone())
+        .unwrap();
+
+    // user can now register
+    let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
+        memo: Some("address".to_string()),
+    };
+    let cosmos_msg = proxy_contract
+        .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
+        .unwrap();
+
+    // register executor
+    app.execute(Addr::unchecked(USER), cosmos_msg.clone())
+        .unwrap();
+
+    let msg = ProxyQueryMsg::GetDataRequestExecutor {
+        executor: Addr::unchecked(USER),
+    };
+    let res: GetDataRequestExecutorResponse = app
+        .wrap()
+        .query_wasm_smart(proxy_contract.addr(), &msg)
+        .unwrap();
+
+    assert_eq!(
+        res,
+        GetDataRequestExecutorResponse {
+            value: Some(DataRequestExecutor {
+                memo: Some("address".to_string()),
+                tokens_staked: 1,
+                tokens_pending_withdrawal: 0
+            })
+        }
+    );
+}

--- a/packages/integration-tests/src/data_request.rs
+++ b/packages/integration-tests/src/data_request.rs
@@ -7,7 +7,7 @@ use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg};
 
 #[test]
 fn post_data_request() {
-    let (mut app, proxy_contract) = proper_instantiate();
+    let (mut app, proxy_contract, _) = proper_instantiate();
 
     let (_, posted_dr) = calculate_dr_id_and_args(1, 3);
     // post the data request

--- a/packages/integration-tests/src/data_result.rs
+++ b/packages/integration-tests/src/data_result.rs
@@ -17,7 +17,7 @@ use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg};
 
 #[test]
 fn commit_reveal_result() {
-    let (mut app, proxy_contract) = proper_instantiate();
+    let (mut app, proxy_contract, _) = proper_instantiate();
 
     // executor 1 should be ineligible to register
     let msg = ProxyQueryMsg::IsDataRequestExecutorEligible {
@@ -247,7 +247,7 @@ fn commit_reveal_result() {
 
 #[test]
 fn ineligible_post_data_result() {
-    let (mut app, proxy_contract) = proper_instantiate();
+    let (mut app, proxy_contract, _) = proper_instantiate();
 
     let (_, posted_dr) = calculate_dr_id_and_args(1, 2);
 
@@ -280,7 +280,7 @@ fn ineligible_post_data_result() {
 
 #[test]
 fn pop_and_swap_in_pool() {
-    let (mut app, proxy_contract) = proper_instantiate();
+    let (mut app, proxy_contract, _) = proper_instantiate();
 
     // send tokens from USER to executor1 and executor2 so they can register
     send_tokens(&mut app, USER, EXECUTOR_1, 1);

--- a/packages/integration-tests/src/executors_registry.rs
+++ b/packages/integration-tests/src/executors_registry.rs
@@ -1,0 +1,127 @@
+use crate::tests::utils::{proper_instantiate, send_tokens, EXECUTOR_1, USER};
+
+use common::{
+    error::ContractError, msg::GetDataRequestExecutorResponse, state::DataRequestExecutor,
+};
+use cosmwasm_std::Addr;
+use cw_multi_test::Executor;
+
+use common::consts::INITIAL_MINIMUM_STAKE_TO_REGISTER;
+use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg};
+
+#[test]
+fn register_data_request_executor() {
+    let (mut app, proxy_contract, _) = proper_instantiate();
+
+    // send tokens from USER to executor1 so it can register
+    send_tokens(&mut app, USER, EXECUTOR_1, 1);
+
+    let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
+        memo: Some("address".to_string()),
+    };
+    let cosmos_msg = proxy_contract
+        .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
+        .unwrap();
+    // register executor
+    app.execute(Addr::unchecked(EXECUTOR_1), cosmos_msg.clone())
+        .unwrap();
+
+    let msg = ProxyQueryMsg::GetDataRequestExecutor {
+        executor: Addr::unchecked(EXECUTOR_1),
+    };
+    let res: GetDataRequestExecutorResponse = app
+        .wrap()
+        .query_wasm_smart(proxy_contract.addr(), &msg)
+        .unwrap();
+
+    assert_eq!(
+        res,
+        GetDataRequestExecutorResponse {
+            value: Some(DataRequestExecutor {
+                memo: Some("address".to_string()),
+                tokens_staked: 1,
+                tokens_pending_withdrawal: 0
+            })
+        }
+    );
+}
+
+#[test]
+fn unregister_data_request_executor() {
+    let (mut app, proxy_contract, _) = proper_instantiate();
+
+    // send tokens from USER to executor1 so it can register
+    send_tokens(&mut app, USER, EXECUTOR_1, 1);
+
+    let msg = ProxyExecuteMsg::RegisterDataRequestExecutor {
+        memo: Some("address".to_string()),
+    };
+    let cosmos_msg = proxy_contract
+        .call_with_deposit(msg, INITIAL_MINIMUM_STAKE_TO_REGISTER)
+        .unwrap();
+    // register executor
+    app.execute(Addr::unchecked(EXECUTOR_1), cosmos_msg.clone())
+        .unwrap();
+
+    let msg = ProxyQueryMsg::GetDataRequestExecutor {
+        executor: Addr::unchecked(EXECUTOR_1),
+    };
+    let res: GetDataRequestExecutorResponse = app
+        .wrap()
+        .query_wasm_smart(proxy_contract.addr(), &msg)
+        .unwrap();
+
+    assert_eq!(
+        res,
+        GetDataRequestExecutorResponse {
+            value: Some(DataRequestExecutor {
+                memo: Some("address".to_string()),
+                tokens_staked: 1,
+                tokens_pending_withdrawal: 0
+            })
+        }
+    );
+
+    // can't unregister the data request executor if it has staked tokens
+    let msg = ProxyExecuteMsg::UnregisterDataRequestExecutor {};
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    // unregister executor
+    let res = app.execute(Addr::unchecked(EXECUTOR_1), cosmos_msg.clone());
+    assert_eq!(
+        res.is_err_and(|x| {
+            x.source().unwrap().source().unwrap().to_string()
+                == ContractError::ExecutorHasTokens.to_string()
+        }),
+        true
+    );
+
+    // unstake
+    let msg = ProxyExecuteMsg::Unstake { amount: 1 };
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    app.execute(Addr::unchecked(EXECUTOR_1), cosmos_msg.clone())
+        .unwrap();
+
+    // withdraw
+    let msg = ProxyExecuteMsg::Withdraw { amount: 1 };
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    app.execute(Addr::unchecked(EXECUTOR_1), cosmos_msg.clone())
+        .unwrap();
+
+    // unregister
+    let msg = ProxyExecuteMsg::UnregisterDataRequestExecutor {};
+    let cosmos_msg = proxy_contract.call(msg).unwrap();
+    // unregister executor
+    app.execute(Addr::unchecked(EXECUTOR_1), cosmos_msg.clone())
+        .unwrap();
+
+    // fetching data request executor for an address that doesn't exist should return None
+    let msg = ProxyQueryMsg::GetDataRequestExecutor {
+        executor: Addr::unchecked("anyone"),
+    };
+    let res: GetDataRequestExecutorResponse = app
+        .wrap()
+        .query_wasm_smart(proxy_contract.addr(), &msg)
+        .unwrap();
+
+    assert_eq!(res, GetDataRequestExecutorResponse { value: None });
+}

--- a/packages/integration-tests/src/governance.rs
+++ b/packages/integration-tests/src/governance.rs
@@ -7,7 +7,7 @@ use proxy_contract::msg::{ProxyExecuteMsg, ProxyQueryMsg, ProxySudoMsg};
 
 #[test]
 fn sudo_set_contract_address() {
-    let (mut app, proxy_contract) = proper_instantiate();
+    let (mut app, proxy_contract, _) = proper_instantiate();
 
     // query initial contract address
     let msg = ProxyQueryMsg::GetDataRequestsContract {};

--- a/packages/integration-tests/src/lib.rs
+++ b/packages/integration-tests/src/lib.rs
@@ -1,8 +1,10 @@
 #[path = ""]
 #[cfg(test)]
 mod tests {
+    mod allowlist;
     mod data_request;
     mod data_result;
+    mod executors_registry;
     mod governance;
     mod staking;
     pub mod utils;

--- a/packages/proxy/src/bin/schema.rs
+++ b/packages/proxy/src/bin/schema.rs
@@ -1,10 +1,10 @@
 use cosmwasm_schema::write_api;
 
-use proxy_contract::msg::{InstantiateMsg, ProxyExecuteMsg, ProxyQueryMsg, ProxySudoMsg};
+use proxy_contract::msg::{ProxyExecuteMsg, ProxyInstantiateMsg, ProxyQueryMsg, ProxySudoMsg};
 
 fn main() {
     write_api! {
-        instantiate: InstantiateMsg,
+        instantiate: ProxyInstantiateMsg,
         execute: ProxyExecuteMsg,
         query: ProxyQueryMsg,
         sudo: ProxySudoMsg,

--- a/packages/proxy/src/contract.rs
+++ b/packages/proxy/src/contract.rs
@@ -21,7 +21,7 @@ use cw2::set_contract_version;
 use cw_utils::parse_reply_execute_data;
 
 use crate::{
-    msg::{InstantiateMsg, ProxyExecuteMsg, ProxyQueryMsg, ProxySudoMsg},
+    msg::{ProxyExecuteMsg, ProxyInstantiateMsg, ProxyQueryMsg, ProxySudoMsg},
     state::{CONTRACT_CREATOR, DATA_REQUESTS, STAKING},
 };
 
@@ -36,7 +36,7 @@ pub fn instantiate(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    msg: InstantiateMsg,
+    msg: ProxyInstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     TOKEN.save(deps.storage, &msg.token)?;
@@ -112,7 +112,7 @@ pub fn execute(
                 msg: to_json_binary(&DataRequestsExecuteMsg::CommitDataResult {
                     dr_id,
                     commitment,
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                 })?,
                 funds: vec![],
             }))
@@ -123,7 +123,7 @@ pub fn execute(
                 msg: to_json_binary(&DataRequestsExecuteMsg::RevealDataResult {
                     dr_id,
                     reveal,
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                 })?,
                 funds: vec![],
             }))
@@ -140,7 +140,7 @@ pub fn execute(
                     contract_addr: STAKING.load(deps.storage)?.to_string(),
                     msg: to_json_binary(&StakingExecuteMsg::RegisterDataRequestExecutor {
                         memo,
-                        sender: Some(info.sender.to_string()),
+                        sender: info.sender.to_string(),
                     })?,
                     funds: vec![Coin {
                         denom: token,
@@ -153,7 +153,7 @@ pub fn execute(
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: STAKING.load(deps.storage)?.to_string(),
                 msg: to_json_binary(&StakingExecuteMsg::UnregisterDataRequestExecutor {
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                 })?,
                 funds: vec![],
             }))
@@ -167,7 +167,7 @@ pub fn execute(
                 .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: STAKING.load(deps.storage)?.to_string(),
                     msg: to_json_binary(&StakingExecuteMsg::DepositAndStake {
-                        sender: Some(info.sender.to_string()),
+                        sender: info.sender.to_string(),
                     })?,
                     funds: vec![Coin {
                         denom: token,
@@ -181,7 +181,7 @@ pub fn execute(
                 contract_addr: STAKING.load(deps.storage)?.to_string(),
                 msg: to_json_binary(&StakingExecuteMsg::Unstake {
                     amount,
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                 })?,
                 funds: vec![],
             }))
@@ -191,7 +191,7 @@ pub fn execute(
                 contract_addr: STAKING.load(deps.storage)?.to_string(),
                 msg: to_json_binary(&StakingExecuteMsg::Withdraw {
                     amount,
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                 })?,
                 funds: vec![],
             }))
@@ -200,7 +200,7 @@ pub fn execute(
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: STAKING.load(deps.storage)?.to_string(),
                 msg: to_json_binary(&StakingExecuteMsg::AddToAllowlist {
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                     address,
                 })?,
                 funds: vec![],
@@ -210,7 +210,7 @@ pub fn execute(
             .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: STAKING.load(deps.storage)?.to_string(),
                 msg: to_json_binary(&StakingExecuteMsg::RemoveFromAllowlist {
-                    sender: Some(info.sender.to_string()),
+                    sender: info.sender.to_string(),
                     address,
                 })?,
                 funds: vec![],
@@ -375,7 +375,7 @@ mod init_tests {
     fn contract_already_set() {
         let mut deps = mock_dependencies();
 
-        let msg = InstantiateMsg {
+        let msg = ProxyInstantiateMsg {
             token: "token".to_string(),
         };
         let info = mock_info("creator", &coins(1000, "token"));
@@ -399,7 +399,7 @@ mod init_tests {
     fn no_funds_provided() {
         let mut deps = mock_dependencies();
 
-        let msg = InstantiateMsg {
+        let msg = ProxyInstantiateMsg {
             token: "token".to_string(),
         };
         let info = mock_info("creator", &coins(1000, "token"));
@@ -421,7 +421,7 @@ mod init_tests {
     fn not_contract_creator() {
         let mut deps = mock_dependencies();
 
-        let msg = InstantiateMsg {
+        let msg = ProxyInstantiateMsg {
             token: "token".to_string(),
         };
         let info = mock_info("creator", &coins(1000, "token"));

--- a/packages/proxy/src/msg.rs
+++ b/packages/proxy/src/msg.rs
@@ -14,7 +14,7 @@ use cosmwasm_std::Addr;
 
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[cw_serde]
-pub struct InstantiateMsg {
+pub struct ProxyInstantiateMsg {
     pub token: String,
 }
 

--- a/packages/staking/src/allowlist.rs
+++ b/packages/staking/src/allowlist.rs
@@ -1,6 +1,9 @@
 pub mod allow_list {
-    use crate::state::{ALLOWLIST, OWNER};
-    use crate::utils::validate_sender;
+    use crate::{
+        state::{ALLOWLIST, OWNER},
+        utils::caller_is_proxy,
+    };
+    // use crate::utils::validate_sender;
     use common::error::ContractError;
     #[cfg(not(feature = "library"))]
     use cosmwasm_std::{Addr, DepsMut, MessageInfo, Response};
@@ -8,11 +11,11 @@ pub mod allow_list {
     pub fn add_to_allowlist(
         deps: DepsMut,
         info: MessageInfo,
-        sender: Option<String>,
+        sender: String,
         address: Addr,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
-
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
         // require the sender to be the OWNER
         let owner = OWNER.load(deps.storage)?;
         if sender != owner {
@@ -28,10 +31,11 @@ pub mod allow_list {
     pub fn remove_from_allowlist(
         deps: DepsMut,
         info: MessageInfo,
-        sender: Option<String>,
+        sender: String,
         address: Addr,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
 
         // require the sender to be the OWNER
         let owner = OWNER.load(deps.storage)?;
@@ -43,89 +47,5 @@ pub mod allow_list {
         ALLOWLIST.remove(deps.storage, address);
 
         Ok(Response::new())
-    }
-}
-
-#[cfg(test)]
-mod executers_tests {
-    use crate::helpers::helper_add_to_allowlist;
-    use crate::helpers::helper_register_executor;
-    use crate::helpers::helper_remove_from_allowlist;
-    use crate::helpers::helper_set_staking_config;
-    use crate::helpers::helper_unregister_executor;
-    use crate::helpers::helper_unstake;
-    use crate::helpers::helper_withdraw;
-    use crate::helpers::instantiate_staking_contract;
-    use common::error::ContractError;
-    use common::state::StakingConfig;
-    use cosmwasm_std::coins;
-    use cosmwasm_std::testing::{mock_dependencies, mock_info};
-
-    #[test]
-    pub fn allowlist_works() {
-        let mut deps = mock_dependencies();
-
-        let info = mock_info("creator", &coins(2, "token"));
-        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
-
-        // update the config with allowlist enabled
-        let info = mock_info("owner", &coins(0, "token"));
-        let new_config = StakingConfig {
-            minimum_stake_to_register: 100,
-            minimum_stake_for_committee_eligibility: 200,
-            allowlist_enabled: true,
-        };
-        let res = helper_set_staking_config(deps.as_mut(), info, new_config);
-        assert!(res.is_ok());
-
-        // alice tries to register a data request executor, but she's not on the allowlist
-        let info = mock_info("alice", &coins(100, "token"));
-        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
-        assert_eq!(res.is_err_and(|x| x == ContractError::NotOnAllowlist), true);
-
-        // add alice to the allowlist
-        let info = mock_info("owner", &coins(0, "token"));
-        let res = helper_add_to_allowlist(deps.as_mut(), info, "alice".to_string(), None);
-        assert!(res.is_ok());
-
-        // now alice can register a data request executor
-        let info = mock_info("alice", &coins(100, "token"));
-        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
-        assert!(res.is_ok());
-
-        // alice unstakes, withdraws, then unregisters herself
-        let info = mock_info("alice", &coins(0, "token"));
-        let _res = helper_unstake(deps.as_mut(), info.clone(), 100, None);
-        let info = mock_info("alice", &coins(0, "token"));
-        let _res = helper_withdraw(deps.as_mut(), info.clone(), 100, None);
-        let info = mock_info("alice", &coins(0, "token"));
-        let res = helper_unregister_executor(deps.as_mut(), info, None);
-        println!("{:?}", res);
-        assert!(res.is_ok());
-
-        // remove alice from the allowlist
-        let info = mock_info("owner", &coins(0, "token"));
-        let res = helper_remove_from_allowlist(deps.as_mut(), info, "alice".to_string(), None);
-        assert!(res.is_ok());
-
-        // now alice can't register a data request executor
-        let info = mock_info("alice", &coins(2, "token"));
-        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
-        assert_eq!(res.is_err_and(|x| x == ContractError::NotOnAllowlist), true);
-
-        // update the config to disable the allowlist
-        let info = mock_info("owner", &coins(0, "token"));
-        let new_config = StakingConfig {
-            minimum_stake_to_register: 100,
-            minimum_stake_for_committee_eligibility: 200,
-            allowlist_enabled: false,
-        };
-        let res = helper_set_staking_config(deps.as_mut(), info, new_config);
-        assert!(res.is_ok());
-
-        // now alice can register a data request executor
-        let info = mock_info("alice", &coins(100, "token"));
-        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
-        assert!(res.is_ok());
     }
 }

--- a/packages/staking/src/contract.rs
+++ b/packages/staking/src/contract.rs
@@ -139,7 +139,7 @@ mod init_tests {
             deps.as_mut(),
             info,
             Some("address".to_string()),
-            Some("sender".to_string()),
+            "sender".to_string(),
         );
         assert_eq!(res.is_err_and(|x| x == ContractError::NotProxy), true);
 
@@ -150,7 +150,7 @@ mod init_tests {
             deps.as_mut(),
             info,
             Some("address".to_string()),
-            Some("sender".to_string()),
+            "sender".to_string(),
         )
         .unwrap();
     }

--- a/packages/staking/src/executors_registry.rs
+++ b/packages/staking/src/executors_registry.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::{Deps, DepsMut, MessageInfo, Response, StdResult};
 
 use crate::state::{CONFIG, DATA_REQUEST_EXECUTORS, TOKEN};
-use crate::utils::{get_attached_funds, validate_sender};
+use crate::utils::get_attached_funds;
 
 use common::msg::GetDataRequestExecutorResponse;
 use common::state::DataRequestExecutor;
@@ -14,7 +14,7 @@ pub mod data_request_executors {
     use crate::{
         contract::CONTRACT_VERSION,
         state::{ALLOWLIST, ELIGIBLE_DATA_REQUEST_EXECUTORS},
-        utils::apply_validator_eligibility,
+        utils::{apply_validator_eligibility, caller_is_proxy},
     };
 
     use super::*;
@@ -24,9 +24,10 @@ pub mod data_request_executors {
         deps: DepsMut,
         info: MessageInfo,
         memo: Option<String>,
-        sender: Option<String>,
+        sender: String,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
 
         // if allowlist is on, check if the sender is in the allowlist
         let allowlist_enabled = CONFIG.load(deps.storage)?.allowlist_enabled;
@@ -73,9 +74,10 @@ pub mod data_request_executors {
     pub fn unregister_data_request_executor(
         deps: DepsMut,
         info: MessageInfo,
-        sender: Option<String>,
+        sender: String,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
 
         // require that the executor has no staked or tokens pending withdrawal
         let executor = DATA_REQUEST_EXECUTORS.load(deps.storage, sender.clone())?;
@@ -111,112 +113,5 @@ pub mod data_request_executors {
         Ok(IsDataRequestExecutorEligibleResponse {
             value: executor.is_some(),
         })
-    }
-}
-
-#[cfg(test)]
-mod executers_tests {
-    use super::*;
-    use crate::contract::execute;
-    use crate::helpers::helper_get_executor;
-    use crate::helpers::helper_register_executor;
-    use crate::helpers::helper_unregister_executor;
-    use crate::helpers::helper_unstake;
-    use crate::helpers::helper_withdraw;
-    use crate::helpers::instantiate_staking_contract;
-    use common::error::ContractError;
-    use common::msg::StakingExecuteMsg as ExecuteMsg;
-    use cosmwasm_std::testing::mock_env;
-    use cosmwasm_std::testing::{mock_dependencies, mock_info};
-    use cosmwasm_std::{coins, Addr};
-
-    #[test]
-    fn register_data_request_executor() {
-        let mut deps = mock_dependencies();
-
-        let info = mock_info("creator", &coins(2, "token"));
-        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
-
-        // fetching data request executor for an address that doesn't exist should return None
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(value, GetDataRequestExecutorResponse { value: None });
-
-        // someone registers a data request executor
-        let info = mock_info("anyone", &coins(2, "token"));
-
-        let _res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None)
-            .unwrap();
-
-        // should be able to fetch the data request executor
-
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-        assert_eq!(
-            value,
-            GetDataRequestExecutorResponse {
-                value: Some(DataRequestExecutor {
-                    memo: Some("address".to_string()),
-                    tokens_staked: 2,
-                    tokens_pending_withdrawal: 0
-                })
-            }
-        );
-    }
-
-    #[test]
-    fn unregister_data_request_executor() {
-        let mut deps = mock_dependencies();
-
-        let info = mock_info("creator", &coins(2, "token"));
-        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
-
-        // someone registers a data request executor
-        let info = mock_info("anyone", &coins(2, "token"));
-
-        let _res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None)
-            .unwrap();
-
-        // should be able to fetch the data request executor
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(
-            value,
-            GetDataRequestExecutorResponse {
-                value: Some(DataRequestExecutor {
-                    memo: Some("address".to_string()),
-                    tokens_staked: 2,
-                    tokens_pending_withdrawal: 0
-                })
-            }
-        );
-
-        // can't unregister the data request executor if it has staked tokens
-        let info = mock_info("anyone", &coins(2, "token"));
-        let msg = ExecuteMsg::UnregisterDataRequestExecutor { sender: None };
-        let res = execute(deps.as_mut(), mock_env(), info, msg);
-        assert_eq!(
-            res.is_err_and(|x| x == ContractError::ExecutorHasTokens),
-            true
-        );
-
-        // unstake and withdraw all tokens
-        let info = mock_info("anyone", &coins(0, "token"));
-
-        let _res = helper_unstake(deps.as_mut(), info.clone(), 2, None);
-        let info = mock_info("anyone", &coins(0, "token"));
-        let _res = helper_withdraw(deps.as_mut(), info.clone(), 2, None);
-
-        // unregister the data request executor
-        let info = mock_info("anyone", &coins(2, "token"));
-        let _res = helper_unregister_executor(deps.as_mut(), info, None).unwrap();
-
-        // fetching data request executor after unregistering should return None
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(value, GetDataRequestExecutorResponse { value: None });
     }
 }

--- a/packages/staking/src/helpers.rs
+++ b/packages/staking/src/helpers.rs
@@ -26,12 +26,11 @@ pub fn helper_register_executor(
     deps: DepsMut,
     info: MessageInfo,
     memo: Option<String>,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::RegisterDataRequestExecutor { memo, sender };
     execute(deps, mock_env(), info, msg)
 }
-
 pub fn helper_transfer_ownership(
     deps: DepsMut,
     info: MessageInfo,
@@ -50,7 +49,7 @@ pub fn helper_accept_ownership(
 pub fn helper_unregister_executor(
     deps: DepsMut,
     info: MessageInfo,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::UnregisterDataRequestExecutor { sender };
     execute(deps, mock_env(), info, msg)
@@ -85,7 +84,7 @@ pub fn helper_get_pending_owner(deps: DepsMut) -> GetPendingOwnerResponse {
 pub fn helper_deposit_and_stake(
     deps: DepsMut,
     info: MessageInfo,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::DepositAndStake { sender };
     execute(deps, mock_env(), info, msg)
@@ -95,7 +94,7 @@ pub fn helper_unstake(
     deps: DepsMut,
     info: MessageInfo,
     amount: u128,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::Unstake { amount, sender };
     execute(deps, mock_env(), info, msg)
@@ -105,7 +104,7 @@ pub fn helper_withdraw(
     deps: DepsMut,
     info: MessageInfo,
     amount: u128,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::Withdraw { amount, sender };
     execute(deps, mock_env(), info, msg)
@@ -124,7 +123,7 @@ pub fn helper_add_to_allowlist(
     deps: DepsMut,
     info: MessageInfo,
     address: String,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::AddToAllowlist {
         address: Addr::unchecked(address),
@@ -137,7 +136,7 @@ pub fn helper_remove_from_allowlist(
     deps: DepsMut,
     info: MessageInfo,
     address: String,
-    sender: Option<String>,
+    sender: String,
 ) -> Result<Response, ContractError> {
     let msg = StakingExecuteMsg::RemoveFromAllowlist {
         address: Addr::unchecked(address),

--- a/packages/staking/src/staking.rs
+++ b/packages/staking/src/staking.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use crate::state::DATA_REQUEST_EXECUTORS;
 
 use crate::state::TOKEN;
-use crate::utils::{get_attached_funds, validate_sender};
+use crate::utils::get_attached_funds;
 
 #[allow(clippy::module_inception)]
 pub mod staking {
@@ -14,7 +14,7 @@ pub mod staking {
     use crate::{
         contract::CONTRACT_VERSION,
         state::{CONFIG, OWNER, PENDING_OWNER},
-        utils::apply_validator_eligibility,
+        utils::{apply_validator_eligibility, caller_is_proxy},
     };
 
     use super::*;
@@ -24,9 +24,10 @@ pub mod staking {
         deps: DepsMut,
         _env: Env,
         info: MessageInfo,
-        sender: Option<String>,
+        sender: String,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
 
         let token = TOKEN.load(deps.storage)?;
         let amount = get_attached_funds(&info.funds, &token)?;
@@ -65,9 +66,10 @@ pub mod staking {
         _env: Env,
         info: MessageInfo,
         amount: u128,
-        sender: Option<String>,
+        sender: String,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
 
         // error if amount is greater than staked tokens
         let mut executor = DATA_REQUEST_EXECUTORS.load(deps.storage, sender.clone())?;
@@ -113,9 +115,10 @@ pub mod staking {
         _env: Env,
         info: MessageInfo,
         amount: u128,
-        sender: Option<String>,
+        sender: String,
     ) -> Result<Response, ContractError> {
-        let sender = validate_sender(&deps, info.sender, sender)?;
+        let sender = deps.api.addr_validate(&sender)?;
+        caller_is_proxy(&deps, info.sender)?;
 
         // TODO: add delay after calling unstake
         let token = TOKEN.load(deps.storage)?;
@@ -229,185 +232,5 @@ pub mod staking {
                     &config.minimum_stake_to_register.to_string(),
                 ),
             ])]))
-    }
-}
-
-#[cfg(test)]
-mod staking_tests {
-
-    use crate::contract::execute;
-    use crate::helpers::helper_deposit_and_stake;
-    use crate::helpers::helper_get_executor;
-    use crate::helpers::helper_register_executor;
-    use crate::helpers::helper_unstake;
-    use crate::helpers::helper_withdraw;
-    use crate::helpers::instantiate_staking_contract;
-    use crate::state::ELIGIBLE_DATA_REQUEST_EXECUTORS;
-    use common::error::ContractError;
-    use common::msg::GetDataRequestExecutorResponse;
-    use common::msg::StakingExecuteMsg as ExecuteMsg;
-    use common::state::DataRequestExecutor;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coins, Addr};
-    #[test]
-    fn deposit_stake_withdraw() {
-        let mut deps = mock_dependencies();
-
-        let info = mock_info("creator", &coins(0, "token"));
-        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
-
-        // cant register without depositing tokens
-        let info = mock_info("anyone", &coins(0, "token"));
-
-        let res = helper_register_executor(deps.as_mut(), info, Some("address".to_string()), None);
-        assert_eq!(res.unwrap_err(), ContractError::InsufficientFunds(1, 0));
-
-        // register a data request executor
-        let info = mock_info("anyone", &coins(1, "token"));
-
-        let _res = helper_register_executor(
-            deps.as_mut(),
-            info.clone(),
-            Some("address".to_string()),
-            None,
-        );
-        let executor_is_eligible: bool = ELIGIBLE_DATA_REQUEST_EXECUTORS
-            .load(&deps.storage, info.sender.clone())
-            .unwrap();
-        assert!(executor_is_eligible);
-        // data request executor's stake should be 1
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(
-            value,
-            GetDataRequestExecutorResponse {
-                value: Some(DataRequestExecutor {
-                    memo: Some("address".to_string()),
-                    tokens_staked: 1,
-                    tokens_pending_withdrawal: 0
-                })
-            }
-        );
-
-        // the data request executor stakes 2 more tokens
-        let info = mock_info("anyone", &coins(2, "token"));
-        let _res = helper_deposit_and_stake(deps.as_mut(), info.clone(), None).unwrap();
-        let executor_is_eligible = ELIGIBLE_DATA_REQUEST_EXECUTORS
-            .load(&deps.storage, info.sender.clone())
-            .unwrap();
-        assert!(executor_is_eligible);
-        // data request executor's stake should be 3
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(
-            value,
-            GetDataRequestExecutorResponse {
-                value: Some(DataRequestExecutor {
-                    memo: Some("address".to_string()),
-                    tokens_staked: 3,
-                    tokens_pending_withdrawal: 0
-                })
-            }
-        );
-
-        // the data request executor unstakes 1
-        let info = mock_info("anyone", &coins(0, "token"));
-
-        let _res = helper_unstake(deps.as_mut(), info.clone(), 1, None);
-        let executor_is_eligible = ELIGIBLE_DATA_REQUEST_EXECUTORS
-            .load(&deps.storage, info.sender.clone())
-            .unwrap();
-        assert!(executor_is_eligible);
-        // data request executor's stake should be 1 and pending 1
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(
-            value,
-            GetDataRequestExecutorResponse {
-                value: Some(DataRequestExecutor {
-                    memo: Some("address".to_string()),
-                    tokens_staked: 2,
-                    tokens_pending_withdrawal: 1
-                })
-            }
-        );
-
-        // the data request executor withdraws 1
-        let info = mock_info("anyone", &coins(0, "token"));
-        let _res = helper_withdraw(deps.as_mut(), info.clone(), 1, None);
-
-        let executor_is_eligible = ELIGIBLE_DATA_REQUEST_EXECUTORS
-            .load(&deps.storage, info.sender.clone())
-            .unwrap();
-        assert!(executor_is_eligible);
-
-        // data request executor's stake should be 1 and pending 0
-        let value: GetDataRequestExecutorResponse =
-            helper_get_executor(deps.as_mut(), Addr::unchecked("anyone"));
-
-        assert_eq!(
-            value,
-            GetDataRequestExecutorResponse {
-                value: Some(DataRequestExecutor {
-                    memo: Some("address".to_string()),
-                    tokens_staked: 2,
-                    tokens_pending_withdrawal: 0
-                })
-            }
-        );
-
-        // unstake 2 more
-        let info = mock_info("anyone", &coins(0, "token"));
-        let msg = ExecuteMsg::Unstake {
-            amount: 2,
-            sender: None,
-        };
-        let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
-
-        // assert executer is no longer eligible for committe inclusion
-        let executor_is_eligible =
-            ELIGIBLE_DATA_REQUEST_EXECUTORS.has(&deps.storage, info.sender.clone());
-        assert!(!executor_is_eligible);
-    }
-
-    #[test]
-    #[should_panic(expected = "NoFunds")]
-    fn no_funds_provided() {
-        let mut deps = mock_dependencies();
-
-        let info = mock_info("creator", &coins(2, "token"));
-        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
-
-        let msg = ExecuteMsg::DepositAndStake { sender: None };
-        let info = mock_info("anyone", &[]);
-        execute(deps.as_mut(), mock_env(), info, msg).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "InsufficientFunds")]
-    fn insufficient_funds() {
-        let mut deps = mock_dependencies();
-
-        let info = mock_info("creator", &coins(2, "token"));
-        let _res = instantiate_staking_contract(deps.as_mut(), info).unwrap();
-
-        // register a data request executor
-        let info = mock_info("anyone", &coins(1, "token"));
-        let msg = ExecuteMsg::RegisterDataRequestExecutor {
-            memo: Some("address".to_string()),
-            sender: None,
-        };
-        execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
-
-        // try unstaking more than staked
-        let info = mock_info("anyone", &coins(0, "token"));
-        let msg = ExecuteMsg::Unstake {
-            amount: 2,
-            sender: None,
-        };
-        execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
     }
 }

--- a/packages/staking/src/utils.rs
+++ b/packages/staking/src/utils.rs
@@ -30,17 +30,10 @@ pub fn get_attached_funds(funds: &[Coin], token: &str) -> Result<u128, ContractE
     amount.ok_or(ContractError::NoFunds)
 }
 
-pub fn validate_sender(
-    deps: &DepsMut,
-    caller: Addr,
-    sender: Option<String>,
-) -> Result<Addr, ContractError> {
-    // if a sender is passed, caller must be the proxy contract
-    match sender {
-        Some(_sender) if caller != PROXY_CONTRACT.load(deps.storage)? => {
-            Err(ContractError::NotProxy {})
-        }
-        Some(sender) => Ok(deps.api.addr_validate(&sender)?),
-        None => Ok(caller),
+pub fn caller_is_proxy(deps: &DepsMut, caller: Addr) -> Result<(), ContractError> {
+    if caller != PROXY_CONTRACT.load(deps.storage)? {
+        Err(ContractError::NotProxy {})
+    } else {
+        Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

To reduce complexity and ensure better maintainability, we should force all Execute calls to be routed through the Proxy.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Add `proxy_is_caller` fn instead of `validate_sender` to separate asserting the proxy caller.
- Move some unit tests to integration tests to properly test the flow after it's no longer valid to do the calls on the staking contract.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes: #133 
