### PR TITLE
Fix: json and binary bugs

### DIFF
--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -26,7 +26,7 @@ impl Execute {
         // TODO: review this event
         let res = Response::new()
             .add_attribute("action", "post_data_request")
-            .set_data(Binary::from(dr_id))
+            .set_data(to_json_binary(&dr_id)?)
             .add_event(Event::new("seda-data-request").add_attributes([
                 ("version", CONTRACT_VERSION.to_string()),
                 ("dr_id", dr_id.to_hex()),

--- a/contract/src/msgs/data_requests/mod.rs
+++ b/contract/src/msgs/data_requests/mod.rs
@@ -68,9 +68,9 @@ pub struct DataRequest {
     /// Amount of required DR executors
     pub replication_factor: u16,
     /// Amount of SEDA tokens per gas unit
-    pub gas_price:          u128,
+    pub gas_price:          Uint128,
     /// Maximum of gas units to be used by data request executors to resolve a data request
-    pub gas_limit:          u128,
+    pub gas_limit:          Uint128,
     /// Public info attached to DR
     pub memo:               Memo,
 
@@ -142,7 +142,7 @@ pub struct DataResult {
     pub block_height: u64,
     /// Exit code of Tally WASM binary execution
     pub exit_code:    u8,
-    pub gas_used:     u128,
+    pub gas_used:     Uint128,
     /// Result from Tally WASM binary execution
     pub result:       Vec<u8>,
 
@@ -172,7 +172,7 @@ impl Hasher for DataResult {
 pub struct RevealBody {
     pub salt:      [u8; 32],
     pub exit_code: u8,
-    pub gas_used:  u128,
+    pub gas_used:  Uint128,
     pub reveal:    Vec<u8>,
 }
 
@@ -195,8 +195,8 @@ pub struct PostDataRequestArgs {
     pub tally_binary_id:    Hash,
     pub tally_inputs:       Bytes,
     pub replication_factor: u16,
-    pub gas_price:          u128,
-    pub gas_limit:          u128,
+    pub gas_price:          Uint128,
+    pub gas_limit:          Uint128,
     pub memo:               Memo,
 }
 

--- a/contract/src/msgs/data_requests/test_helpers.rs
+++ b/contract/src/msgs/data_requests/test_helpers.rs
@@ -15,8 +15,8 @@ pub fn calculate_dr_id_and_args(nonce: u128, replication_factor: u16) -> (Hash, 
     let tally_inputs: Bytes = "tally_inputs".as_bytes().to_vec();
 
     // set by dr creator
-    let gas_price: u128 = 10;
-    let gas_limit: u128 = 10;
+    let gas_price = 10u128.into();
+    let gas_limit = 10u128.into();
 
     // memo
     let chain_id: u128 = 31337;

--- a/contract/src/msgs/data_requests/tests.rs
+++ b/contract/src/msgs/data_requests/tests.rs
@@ -212,7 +212,7 @@ fn reveal_result() {
     let alice_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "10".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -231,7 +231,7 @@ fn reveal_result() {
     let bob_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "20".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -277,7 +277,7 @@ fn reveals_meet_replication_factor() {
     let alice_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "10".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -296,7 +296,7 @@ fn reveals_meet_replication_factor() {
     let bob_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "20".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -357,7 +357,7 @@ fn cannot_reveal_if_commit_rf_not_met() {
     let alice_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "10".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -400,7 +400,7 @@ fn cannot_reveal_if_user_did_not_commit() {
     let alice_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "10".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -419,7 +419,7 @@ fn cannot_reveal_if_user_did_not_commit() {
     let bob_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "20".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
 
@@ -456,7 +456,7 @@ fn cannot_double_reveal() {
     let alice_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "10".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -475,7 +475,7 @@ fn cannot_double_reveal() {
     let bob_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "20".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -530,7 +530,7 @@ fn reveal_must_match_commitment() {
     let alice_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "10".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(
@@ -541,7 +541,7 @@ fn reveal_must_match_commitment() {
         RevealBody {
             salt:      alice.salt(),
             reveal:    "11".hash().to_vec(),
-            gas_used:  0,
+            gas_used:  0u128.into(),
             exit_code: 0,
         }
         .hash(),
@@ -555,7 +555,7 @@ fn reveal_must_match_commitment() {
     let bob_reveal = RevealBody {
         salt:      alice.salt(),
         reveal:    "20".hash().to_vec(),
-        gas_used:  0,
+        gas_used:  0u128.into(),
         exit_code: 0,
     };
     test_helpers::commit_result(


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Some of the messages would say `enum variant not found`(thanks for the shitty error serde), and needed to be Uint128's not u128's. Similarly, the binary on `post_data_request` was invalid due to how we were sending it.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Replace all u128's with Uint128's. There's no loss for this since it wraps around the u128 type.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

All tests still pass.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
