### PR TITLE
Return DR ID as hex string instead of an encoded byte array

### DIFF
--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -16,7 +16,7 @@ impl ExecuteHandler for execute::post_request::Execute {
         let hex_dr_id = dr_id.to_hex();
         let res = Response::new()
             .add_attribute("action", "post_data_request")
-            .set_data(to_json_binary(&dr_id)?)
+            .set_data(to_json_binary(&hex_dr_id)?)
             .add_event(Event::new("seda-data-request").add_attributes([
                 ("version", CONTRACT_VERSION.to_string()),
                 ("dr_id", hex_dr_id.clone()),

--- a/contract/src/msgs/data_requests/types_tests.rs
+++ b/contract/src/msgs/data_requests/types_tests.rs
@@ -78,6 +78,7 @@ fn create_test_dr(nonce: u128) -> (Hash, DataRequest) {
     let args = calculate_dr_id_and_args(nonce, 2);
     let id = nonce.to_string().hash();
     let dr = construct_dr(args, vec![], nonce as u64);
+
     (id, dr)
 }
 


### PR DESCRIPTION
## Motivation

Makes interacting with the contract easier by removing 1 layer of encoding/decoding.

## Explanation of Changes

Fairly straightforward, except since I changed some types I had to modify a lot of existing test code. If there's a better way to do this please educate me :)

## Testing

All the tests still pass.

## Related PRs and Issues

N.A.
