### PR TITLE
refactor(dr): remove seq number in commit and reveal hash

### DIFF
--- a/contract/src/msgs/data_requests/execute/commit_result.rs
+++ b/contract/src/msgs/data_requests/execute/commit_result.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::state::{inc_get_seq, CHAIN_ID};
+use crate::state::CHAIN_ID;
 
 impl ExecuteHandler for execute::commit_result::Execute {
     /// Posts a data result of a data request with an attached hash of the answer and salt.
@@ -28,7 +28,6 @@ impl ExecuteHandler for execute::commit_result::Execute {
             self.commitment.as_bytes(),
             chain_id.as_bytes(),
             env.contract.address.as_str().as_bytes(),
-            &inc_get_seq(deps.storage, &public_key)?.to_be_bytes(),
         ]);
 
         // verify the proof

--- a/contract/src/msgs/data_requests/execute/reveal_result.rs
+++ b/contract/src/msgs/data_requests/execute/reveal_result.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::state::{inc_get_seq, CHAIN_ID};
+use crate::state::CHAIN_ID;
 
 impl ExecuteHandler for execute::reveal_result::Execute {
     /// Posts a data result of a data request with an attached result.
@@ -26,7 +26,6 @@ impl ExecuteHandler for execute::reveal_result::Execute {
             &reveal_body_hash,
             chain_id.as_bytes(),
             env.contract.address.as_str().as_bytes(),
-            &inc_get_seq(deps.storage, &public_key)?.to_be_bytes(),
         ]);
 
         // verify the proof

--- a/contract/src/msgs/data_requests/test_helpers.rs
+++ b/contract/src/msgs/data_requests/test_helpers.rs
@@ -132,7 +132,6 @@ impl TestInfo {
 
     #[track_caller]
     pub fn commit_result(&mut self, sender: &TestExecutor, dr_id: &str, commitment: Hash) -> Result<(), ContractError> {
-        let seq = self.get_account_sequence(sender.pub_key());
         let dr = self.get_dr(dr_id).unwrap();
         let commitment = commitment.to_hex();
         let msg_hash = hash([
@@ -142,7 +141,6 @@ impl TestInfo {
             commitment.as_bytes(),
             self.chain_id(),
             self.contract_addr_bytes(),
-            &seq.to_be_bytes(),
         ]);
 
         let msg = execute::commit_result::Execute {
@@ -163,7 +161,6 @@ impl TestInfo {
         dr_id: &str,
         commitment: Hash,
     ) -> Result<(), ContractError> {
-        let seq = self.get_account_sequence(sender.pub_key());
         let dr = self.get_dr(dr_id).unwrap();
         let commitment = commitment.to_hex();
         let msg_hash = hash([
@@ -173,7 +170,6 @@ impl TestInfo {
             commitment.as_bytes(),
             self.chain_id(),
             self.contract_addr_bytes(),
-            &seq.to_be_bytes(),
         ]);
 
         let msg = execute::commit_result::Execute {
@@ -194,7 +190,6 @@ impl TestInfo {
         dr_id: &str,
         reveal_body: RevealBody,
     ) -> Result<(), ContractError> {
-        let seq = self.get_account_sequence(sender.pub_key());
         let dr = self.get_dr(dr_id).unwrap();
         let msg_hash = hash([
             "reveal_data_result".as_bytes(),
@@ -203,7 +198,6 @@ impl TestInfo {
             &reveal_body.try_hash()?,
             self.chain_id(),
             self.contract_addr_bytes(),
-            &seq.to_be_bytes(),
         ]);
 
         let msg = execute::reveal_result::Execute {


### PR DESCRIPTION
## Motivation

Most contract transactions include a hashed value derived from variables like dr_id, block_height, and sequence_number. This approach helps protect transactions from replay attacks, where a malicious user could resend previous transactions to perform actions such as staking, unstaking, and withdrawing.

For consistency, this mechanism was also applied to data_request transactions. However, because identities might submit multiple commit and reveal transactions simultaneously, including the sequence_number adds complexity and affects the performance of an executor node using the same identity for multiple data requests. The dr_id and block_height variables are sufficient to protect data request transactions.

## Explanation of Changes

Remove the sequence_number from the hash value in contract transactions.

## Testing

Remove the sequence_number from the hash value in contract transactions.