### PR TITLE
Emit commit details on contract instantiation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ wasm = "run --package xtask -- wasm"
 wasm-opt = "run --package xtask -- wasm-opt"
 xtask = "run --package xtask --"
 tally-data-req-fixture = "run --package xtask -- tally-data-req-fixture"
+
+[env]
+GIT_REVISION = "unknown"

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -21,6 +21,7 @@ use crate::{
 // version info for migration info
 const CONTRACT_NAME: &str = "staking";
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const GIT_REVISION: &str = env!("GIT_REVISION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -42,7 +43,9 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &init_config)?;
     crate::msgs::data_requests::state::init_data_requests(deps.storage)?;
 
-    Ok(Response::new().add_attribute("method", "instantiate"))
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("git_revision", GIT_REVISION))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,6 +59,7 @@ fn wasm(sh: &Shell) -> Result<()> {
         "cargo build -p seda-contract --release --lib --target wasm32-unknown-unknown --locked"
     )
     .env("RUSTFLAGS", "-C link-arg=-s")
+    .env("GIT_REVISION", get_git_version()?)
     .run()?;
     Ok(())
 }
@@ -160,4 +161,17 @@ fn tally_data_req_fixture(_sh: &Shell) -> Result<()> {
     )?;
 
     Ok(())
+}
+
+fn get_git_version() -> Result<String> {
+    let git_version = Command::new("git")
+        .args(["describe", "--always", "--dirty=-modified", "--tags"])
+        .output()
+        .context("Invoking git describe")?;
+    if !git_version.status.success() {
+        return Ok("unknown".to_string());
+    }
+
+    let version = String::from_utf8(git_version.stdout)?;
+    Ok(version)
 }


### PR DESCRIPTION
## Motivation

This should make it easier to figure out 'where' a contract was built from.

## Explanation of Changes

I emitted it during the instantiation so we don't have to allocate extra state storage for it, but that does mean we can only see the details in the tx/endblock where the contract was actually instantiated.

It would probably be better to only embed this info for debug builds, and if we do that we can probably keep it in state and retrieve it with a query. That's beyond my Rust capabilities though. Also didn't want to spend too much time on this in case we decide it's not useful. :)

Sources used to figure out how to achieve this:
https://github.com/rust-lang/rust-analyzer/issues/13751
https://github.com/near/nearcore/blob/master/neard/build.rs

## Testing

Deployed and instantiated on devnet: https://sedaprotocol.github.io/test-explorer/devnet/tx/ACF61782B4F718A70BC8A178748264D21579A89A5C43800DA3385CE9F443C651

Check the `tx_response.events[type=wasm].attributes[key=git_revision]` in the JSON view.

## Related PRs and Issues

None.
