### PR TITLE
Update events emitted for DR execution messages

### DIFF
--- a/contract/src/msgs/data_requests/execute/commit_result.rs
+++ b/contract/src/msgs/data_requests/execute/commit_result.rs
@@ -3,7 +3,7 @@ use crate::state::CHAIN_ID;
 
 impl ExecuteHandler for execute::commit_result::Execute {
     /// Posts a data result of a data request with an attached hash of the answer and salt.
-    fn execute(self, deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+    fn execute(self, deps: DepsMut, env: Env, _info: MessageInfo) -> Result<Response, ContractError> {
         // find the data request from the pool (if it exists, otherwise error)
         let dr_id = Hash::from_hex_str(&self.dr_id)?;
         let mut dr = state::load_request(deps.storage, &dr_id)?;
@@ -41,10 +41,10 @@ impl ExecuteHandler for execute::commit_result::Execute {
 
         Ok(Response::new().add_attribute("action", "commit_data_result").add_event(
             Event::new("seda-commitment").add_attributes([
-                ("version", CONTRACT_VERSION.to_string()),
                 ("dr_id", self.dr_id),
-                ("executor", info.sender.into_string()),
                 ("commitment", self.commitment),
+                ("executor", self.public_key),
+                ("version", CONTRACT_VERSION.to_string()),
             ]),
         ))
     }

--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -18,18 +18,19 @@ impl ExecuteHandler for execute::post_request::Execute {
             .add_attribute("action", "post_data_request")
             .set_data(to_json_binary(&hex_dr_id)?)
             .add_event(Event::new("seda-data-request").add_attributes([
-                ("version", CONTRACT_VERSION.to_string()),
                 ("dr_id", hex_dr_id.clone()),
                 ("dr_binary_id", self.posted_dr.dr_binary_id.clone()),
-                ("tally_binary_id", self.posted_dr.tally_binary_id.clone()),
                 ("dr_inputs", self.posted_dr.dr_inputs.to_base64()),
+                ("tally_binary_id", self.posted_dr.tally_binary_id.clone()),
                 ("tally_inputs", self.posted_dr.tally_inputs.to_base64()),
-                ("memo", self.posted_dr.memo.to_base64()),
                 ("replication_factor", self.posted_dr.replication_factor.to_string()),
+                ("consensus_filter", self.posted_dr.consensus_filter.to_base64()),
                 ("gas_price", self.posted_dr.gas_price.to_string()),
                 ("gas_limit", self.posted_dr.gas_limit.to_string()),
+                ("memo", self.posted_dr.memo.to_base64()),
                 ("seda_payload", self.seda_payload.to_base64()),
                 ("payback_address", self.payback_address.to_base64()),
+                ("version", self.posted_dr.version.to_string()),
             ]));
 
         // save the data request

--- a/contract/src/msgs/data_requests/execute/reveal_result.rs
+++ b/contract/src/msgs/data_requests/execute/reveal_result.rs
@@ -50,12 +50,13 @@ impl ExecuteHandler for execute::reveal_result::Execute {
 
         let response = Response::new().add_attribute("action", "reveal_data_result").add_event(
             Event::new("seda-reveal").add_attributes([
-                ("version", CONTRACT_VERSION.to_string()),
                 ("dr_id", self.dr_id.clone()),
-                ("executor", info.sender.into_string()),
                 ("reveal", to_json_string(&self.reveal_body)?),
+                ("executor", info.sender.into_string()),
                 ("stdout", to_json_string(&self.stdout)?),
                 ("stderr", to_json_string(&self.stderr)?),
+                ("executor", self.public_key.to_string()),
+                ("version", CONTRACT_VERSION.to_string()),
             ]),
         );
 


### PR DESCRIPTION
## Motivation

Some of the new attributes were not yet emitted.

## Explanation of Changes

Added the `consensus_filter` attribute to the post DR handler.

Changed the executor to the public key string instead of the address that signed the message, as the SEDA address is no longer the identifier for the identity that submitted a commit/reveal.

## Testing

Verified existing tests still pass.

## Related PRs and Issues

N.A.
