### PR TITLE
Update emitted events

### DIFF
--- a/contract/src/msgs/data_requests/state/mod.rs
+++ b/contract/src/msgs/data_requests/state/mod.rs
@@ -77,7 +77,7 @@ pub fn reveal(store: &mut dyn Storage, dr_id: Hash, dr: DataRequest, current_hei
     Ok(())
 }
 
-pub fn post_result(store: &mut dyn Storage, dr_id: Hash) -> StdResult<()> {
+pub fn remove_request(store: &mut dyn Storage, dr_id: Hash) -> StdResult<()> {
     // we have to remove the request from the pool
     DATA_REQUESTS.remove(store, dr_id)?;
     // no need to update status as we remove it from the requests pool

--- a/contract/src/msgs/data_requests/sudo/expire_data_requests.rs
+++ b/contract/src/msgs/data_requests/sudo/expire_data_requests.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{to_json_string, DepsMut, Env, Event, Response};
 use seda_common::msgs::data_requests::sudo::expire_data_requests;
 
-use super::{state, ContractError, SudoHandler, CONTRACT_VERSION};
+use super::{state, ContractError, SudoHandler};
 
 impl SudoHandler for expire_data_requests::Sudo {
     /// Expires all data requests that have timed out
@@ -9,8 +9,7 @@ impl SudoHandler for expire_data_requests::Sudo {
     fn sudo(self, deps: DepsMut, env: Env) -> Result<Response, ContractError> {
         let ids = state::expire_data_requests(deps.storage, env.block.height)?;
 
-        let event = Event::new("seda-result").add_attributes([
-            ("version", CONTRACT_VERSION.to_string()),
+        let event = Event::new("timeout-dr").add_attributes([
             ("current_height", env.block.height.to_string()),
             ("timed_out_drs", to_json_string(&ids)?),
         ]);

--- a/contract/src/msgs/data_requests/sudo/mod.rs
+++ b/contract/src/msgs/data_requests/sudo/mod.rs
@@ -3,12 +3,12 @@ use super::{
     *,
 };
 pub(in crate::msgs::data_requests) mod expire_data_requests;
-pub(in crate::msgs::data_requests) mod post_result;
+pub(in crate::msgs::data_requests) mod remove_request;
 pub(in crate::msgs::data_requests) mod remove_requests;
 
-fn post_result(result: sudo::RemoveDataRequest, deps: &mut DepsMut, env: &Env) -> Result<Event, ContractError> {
+fn remove_request(request: sudo::RemoveDataRequest, deps: &mut DepsMut, env: &Env) -> Result<Event, ContractError> {
     // find the data request from the committed pool (if it exists, otherwise error)
-    let dr_id = Hash::from_hex_str(&result.dr_id)?;
+    let dr_id = Hash::from_hex_str(&request.dr_id)?;
     let dr = state::load_request(deps.storage, &dr_id)?;
 
     if !dr.is_tallying() {
@@ -17,15 +17,10 @@ fn post_result(result: sudo::RemoveDataRequest, deps: &mut DepsMut, env: &Env) -
 
     let block_height: u64 = env.block.height;
 
-    let event = Event::new("seda-result").add_attributes([
-        ("version", CONTRACT_VERSION.to_string()),
-        ("dr_id", result.dr_id),
-        ("block_height", block_height.to_string()),
-        ("payback_address", dr.payback_address.to_base64()),
-        ("seda_payload", dr.seda_payload.to_base64()),
-    ]);
+    let event =
+        Event::new("remove-dr").add_attributes([("dr_id", request.dr_id), ("block_height", block_height.to_string())]);
 
-    state::post_result(deps.storage, dr_id)?;
+    state::remove_request(deps.storage, dr_id)?;
 
     Ok(event)
 }

--- a/contract/src/msgs/data_requests/sudo/remove_request.rs
+++ b/contract/src/msgs/data_requests/sudo/remove_request.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 impl SudoHandler for sudo::RemoveDataRequest {
-    /// Posts a data result to the contract
+    /// Removes a data request from the contract
     fn sudo(self, mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
-        let event = post_result(self, &mut deps, &env)?;
+        let event = remove_request(self, &mut deps, &env)?;
 
         Ok(Response::new().add_event(event))
     }

--- a/contract/src/msgs/data_requests/sudo/remove_requests.rs
+++ b/contract/src/msgs/data_requests/sudo/remove_requests.rs
@@ -1,13 +1,12 @@
 use super::*;
 
 impl SudoHandler for sudo::remove_requests::Sudo {
-    /// Posts data results to the contract
     fn sudo(self, mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
         let mut response = Response::new();
         for event in self
             .requests
             .into_iter()
-            .map(|result| post_result(result, &mut deps, &env))
+            .map(|request| remove_request(request, &mut deps, &env))
         {
             response = response.add_event(event?);
         }

--- a/contract/src/msgs/data_requests/tests.rs
+++ b/contract/src/msgs/data_requests/tests.rs
@@ -704,7 +704,7 @@ fn remove_data_request() {
         .unwrap();
     test_info.reveal_result(&alice, &dr_id, alice_reveal.clone()).unwrap();
 
-    // owner posts a data result
+    // owner removes a data result
     test_info.remove_data_request(dr_id).unwrap();
 }
 
@@ -886,7 +886,7 @@ fn remove_data_request_with_more_drs_in_the_pool() {
     assert_eq!(1, dr_to_be_tallied.len());
     assert_eq!(dr_to_be_tallied[0].id, dr_id1);
 
-    // Post only first dr ready to be tallied (while there is another one in the pool and not ready)
+    // Remove only first dr ready to be tallied (while there is another one in the pool and not ready)
     // This checks part of the swap_remove logic
     let dr = dr_to_be_tallied[0].clone();
     test_info.remove_data_request(dr.id).unwrap();
@@ -902,7 +902,7 @@ fn remove_data_request_with_more_drs_in_the_pool() {
     let dr_to_be_tallied = test_info.get_data_requests_by_status(DataRequestStatus::Tallying, 0, 100);
     assert_eq!(1, dr_to_be_tallied.len());
 
-    // Post last dr result
+    // Remove last dr
     let dr = dr_to_be_tallied[0].clone();
     test_info.remove_data_request(dr.id).unwrap();
 

--- a/contract/src/msgs/staking/tests.rs
+++ b/contract/src/msgs/staking/tests.rs
@@ -253,7 +253,7 @@ fn executor_not_eligible_if_dr_resolved() {
     // reveal
     test_info.reveal_result(&anyone, &dr_id, reveal.clone()).unwrap();
 
-    // Owner posts the result
+    // Owner removes the data request
     test_info.remove_data_request(dr_id.clone()).unwrap();
 
     // perform the check


### PR DESCRIPTION
## Motivation

Now that the results are stored in the batching module it doesn't make sense to emit them from the contract.

## Explanation of Changes

Also rename the post_result function to better communicate what it actually does.

## Testing

Unit tests still pass.

## Related PRs and Issues

N.A.
