### PR TITLE
fix: don't check reveals on posting a result

### DIFF
--- a/contract/src/msgs/data_requests/sudo/mod.rs
+++ b/contract/src/msgs/data_requests/sudo/mod.rs
@@ -9,11 +9,7 @@ pub(in crate::msgs::data_requests) mod remove_requests;
 fn remove_request(request: sudo::RemoveDataRequest, deps: &mut DepsMut, env: &Env) -> Result<Event, ContractError> {
     // find the data request from the committed pool (if it exists, otherwise error)
     let dr_id = Hash::from_hex_str(&request.dr_id)?;
-    let dr = state::load_request(deps.storage, &dr_id)?;
-
-    if !dr.is_tallying() {
-        return Err(ContractError::NotEnoughReveals);
-    }
+    state::load_request(deps.storage, &dr_id)?;
 
     let block_height: u64 = env.block.height;
 

--- a/contract/src/msgs/data_requests/tests.rs
+++ b/contract/src/msgs/data_requests/tests.rs
@@ -755,53 +755,6 @@ fn remove_data_requests() {
 }
 
 #[test]
-#[should_panic = "NotEnoughReveals"]
-fn cant_post_if_replication_factor_not_met() {
-    let mut test_info = TestInfo::init();
-    let mut alice = test_info.new_executor("alice", Some(2));
-    alice.stake(&mut test_info, 1).unwrap();
-    let mut bob = test_info.new_executor("bob", Some(2));
-    bob.stake(&mut test_info, 1).unwrap();
-
-    // post a data request
-    let dr = test_helpers::calculate_dr_id_and_args(1, 2);
-    let dr_id = test_info.post_data_request(&alice, dr, vec![], vec![], 1).unwrap();
-
-    // alice commits a data result
-    let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
-        reveal:            "10".hash().into(),
-        gas_used:          0,
-        exit_code:         0,
-        proxy_public_keys: vec![],
-    };
-    test_info
-        .commit_result(&alice, &dr_id, alice_reveal.try_hash().unwrap())
-        .unwrap();
-
-    // bob also commits
-    let bob_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
-        reveal:            "20".hash().into(),
-        gas_used:          0,
-        exit_code:         0,
-        proxy_public_keys: vec![],
-    };
-    test_info
-        .commit_result(&bob, &dr_id, bob_reveal.try_hash().unwrap())
-        .unwrap();
-
-    // alice reveals
-    test_info.reveal_result(&alice, &dr_id, alice_reveal.clone()).unwrap();
-
-    // post a data result
-    test_info.get_data_request(&dr_id).unwrap();
-    test_info.remove_data_request(dr_id).unwrap();
-}
-
-#[test]
 fn check_data_request_id() {
     // Expected DR ID for following DR:
     // {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So the chain side works.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Removes the check that reveals need to match the replication factor.

However, when we add the 2/3rds check to the chain, we may want to add that here as well? or since it's so, maybe we can always trust the chain.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

All tests pass.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Unblocks https://github.com/sedaprotocol/seda-chain/pull/400.
