### PR TITLE
Touch up event names and attributes

### DIFF
--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -63,7 +63,8 @@ pub fn instantiate(
     crate::msgs::data_requests::state::init_data_requests(deps.storage)?;
 
     Ok(Response::new().add_attribute("method", "instantiate").add_events([
-        Event::new("seda-contract-instantiate").add_attributes([
+        Event::new("seda-contract").add_attributes([
+            ("action", "instantiate".to_string()),
             ("version", CONTRACT_VERSION.to_string()),
             ("chain_id", msg.chain_id),
             ("owner", msg.owner),

--- a/contract/src/msgs/owner/execute/accept_ownership.rs
+++ b/contract/src/msgs/owner/execute/accept_ownership.rs
@@ -15,7 +15,10 @@ impl ExecuteHandler for execute::accept_ownership::Execute {
 
         Ok(Response::new()
             .add_attribute("action", "accept-ownership")
-            .add_events([Event::new("seda-ownership-accept")
-                .add_attributes([("version", CONTRACT_VERSION), ("new_owner", info.sender.as_ref())])]))
+            .add_events([Event::new("seda-contract").add_attributes([
+                ("version", CONTRACT_VERSION.to_string()),
+                ("new_owner", info.sender.to_string()),
+                ("action", "accept-ownership".to_string()),
+            ])]))
     }
 }

--- a/contract/src/msgs/owner/execute/add_to_allowlist.rs
+++ b/contract/src/msgs/owner/execute/add_to_allowlist.rs
@@ -14,8 +14,11 @@ impl ExecuteHandler for execute::add_to_allowlist::Execute {
         ALLOWLIST.save(deps.storage, &public_key, &true)?;
 
         Ok(Response::new().add_attribute("action", "add-to-allowlist").add_event(
-            Event::new("seda-allowlist-add")
-                .add_attributes([("version", CONTRACT_VERSION.to_string()), ("identity", self.public_key)]),
+            Event::new("seda-contract").add_attributes([
+                ("version", CONTRACT_VERSION.to_string()),
+                ("identity", self.public_key),
+                ("action", "allowlist-add".to_string()),
+            ]),
         ))
     }
 }

--- a/contract/src/msgs/owner/execute/remove_from_allowlist.rs
+++ b/contract/src/msgs/owner/execute/remove_from_allowlist.rs
@@ -15,9 +15,10 @@ impl ExecuteHandler for execute::remove_from_allowlist::Execute {
 
         Ok(Response::new()
             .add_attribute("action", "remove-from-allowlist")
-            .add_event(
-                Event::new("seda-allowlist-remove")
-                    .add_attributes([("version", CONTRACT_VERSION.to_string()), ("identity", self.public_key)]),
-            ))
+            .add_event(Event::new("seda-contract").add_attributes([
+                ("version", CONTRACT_VERSION.to_string()),
+                ("identity", self.public_key),
+                ("action", "allowlist-remove".to_string()),
+            ])))
     }
 }

--- a/contract/src/msgs/owner/execute/transfer_ownership.rs
+++ b/contract/src/msgs/owner/execute/transfer_ownership.rs
@@ -10,9 +10,10 @@ impl ExecuteHandler for execute::transfer_ownership::Execute {
 
         Ok(Response::new()
             .add_attribute("action", "transfer_ownership")
-            .add_events([Event::new("seda-ownership-transfer").add_attributes([
+            .add_events([Event::new("seda-contract").add_attributes([
                 ("version", CONTRACT_VERSION.to_string()),
                 ("pending_owner", self.new_owner),
+                ("action", "transfer-ownership".to_string()),
             ])]))
     }
 }

--- a/contract/src/msgs/staking/execute/stake.rs
+++ b/contract/src/msgs/staking/execute/stake.rs
@@ -51,13 +51,7 @@ impl ExecuteHandler for execute::stake::Execute {
         };
 
         Ok(Response::new().add_attribute("action", "stake").add_events([
-            create_executor_action_event(
-                "seda-executor-action-stake",
-                self.public_key.clone(),
-                info.sender.to_string(),
-                amount,
-                seq,
-            ),
+            create_executor_action_event("stake", self.public_key.clone(), info.sender.to_string(), amount, seq),
             create_executor_event(executor, self.public_key),
         ]))
     }

--- a/contract/src/msgs/staking/execute/staking_events.rs
+++ b/contract/src/msgs/staking/execute/staking_events.rs
@@ -23,8 +23,9 @@ pub(in crate::msgs::staking::execute) fn create_executor_action_event(
     amount: Uint128,
     seq: Uint128,
 ) -> Event {
-    Event::new(action).add_attributes([
+    Event::new("seda-executor-action").add_attributes([
         ("version", CONTRACT_VERSION.to_string()),
+        ("action", action.to_string()),
         ("identity", public_key),
         ("sender", sender),
         ("amount", amount.to_string()),

--- a/contract/src/msgs/staking/execute/unstake.rs
+++ b/contract/src/msgs/staking/execute/unstake.rs
@@ -27,7 +27,7 @@ impl ExecuteHandler for execute::unstake::Execute {
 
         Ok(Response::new().add_attribute("action", "unstake").add_events([
             create_executor_action_event(
-                "seda-executor-action-unstake",
+                "unstake",
                 self.public_key.clone(),
                 info.sender.to_string(),
                 self.amount,

--- a/contract/src/msgs/staking/execute/withdraw.rs
+++ b/contract/src/msgs/staking/execute/withdraw.rs
@@ -43,7 +43,7 @@ impl ExecuteHandler for execute::withdraw::Execute {
             .add_attribute("action", "withdraw")
             .add_events([
                 create_executor_action_event(
-                    "seda-executor-action-withdraw",
+                    "withdraw",
                     self.public_key.clone(),
                     info.sender.to_string(),
                     self.amount,


### PR DESCRIPTION
## Motivation

While implementing the parsing logic for the updated events I realised it's easier to have a single event name and differentiate based on the attributes.

## Explanation of Changes

N.A.

## Testing

Deploy on a local chain.

## Related PRs and Issues

Follow up on #226. 
