### PR TITLE
Emit timeout config events

### DIFF
--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     error::ContractError,
     msgs::{
-        data_requests::state::TIMEOUT_CONFIG,
+        data_requests::{execute::dr_events::create_timeout_config_event, state::TIMEOUT_CONFIG},
         owner::state::{OWNER, PENDING_OWNER},
         staking::{
             execute::staking_events::create_staking_config_event,
@@ -72,6 +72,7 @@ pub fn instantiate(
             ("git_revision", GIT_REVISION.to_string()),
         ]),
         create_staking_config_event(init_staking_config),
+        create_timeout_config_event(init_timeout_config),
     ]))
 }
 

--- a/contract/src/msgs/data_requests/execute/dr_events.rs
+++ b/contract/src/msgs/data_requests/execute/dr_events.rs
@@ -1,0 +1,12 @@
+use cosmwasm_std::Event;
+use seda_common::msgs::data_requests::TimeoutConfig;
+
+use super::CONTRACT_VERSION;
+
+pub fn create_timeout_config_event(config: TimeoutConfig) -> Event {
+    Event::new("seda-timeout-config").add_attributes([
+        ("version", CONTRACT_VERSION.to_string()),
+        ("commit_timeout_in_blocks", config.commit_timeout_in_blocks.to_string()),
+        ("reveal_timeout_in_blocks", config.reveal_timeout_in_blocks.to_string()),
+    ])
+}

--- a/contract/src/msgs/data_requests/execute/mod.rs
+++ b/contract/src/msgs/data_requests/execute/mod.rs
@@ -4,6 +4,7 @@ use super::{
 };
 
 pub(in crate::msgs::data_requests) mod commit_result;
+pub(crate) mod dr_events;
 pub(in crate::msgs::data_requests) mod post_request;
 pub(in crate::msgs::data_requests) mod reveal_result;
 pub(in crate::msgs::data_requests) mod set_timeout_config;

--- a/contract/src/msgs/data_requests/execute/set_timeout_config.rs
+++ b/contract/src/msgs/data_requests/execute/set_timeout_config.rs
@@ -1,7 +1,13 @@
-use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
+use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use seda_common::msgs::data_requests::TimeoutConfig;
 
-use super::{owner::state::OWNER, state::TIMEOUT_CONFIG, ContractError, ExecuteHandler, CONTRACT_VERSION};
+use super::{
+    dr_events::create_timeout_config_event,
+    owner::state::OWNER,
+    state::TIMEOUT_CONFIG,
+    ContractError,
+    ExecuteHandler,
+};
 
 impl ExecuteHandler for TimeoutConfig {
     /// Set staking config
@@ -13,10 +19,6 @@ impl ExecuteHandler for TimeoutConfig {
 
         Ok(Response::new()
             .add_attribute("action", "set-timeout-config")
-            .add_events([Event::new("set-timeout-config").add_attributes([
-                ("version", CONTRACT_VERSION.to_string()),
-                ("commit_timeout_in_blocks", self.commit_timeout_in_blocks.to_string()),
-                ("reveal_timeout_in_blocks", self.reveal_timeout_in_blocks.to_string()),
-            ])]))
+            .add_event(create_timeout_config_event(self)))
     }
 }


### PR DESCRIPTION
## Motivation

Allow us to show the timeout config in the explorer.

## Explanation of Changes

Similar to the staking config changes.

## Testing

Deployed on a local chain.

## Related PRs and Issues

N.A.
