### PR TITLE
Return posted height along dr_id on post_data_request

### DIFF
--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -1,6 +1,13 @@
+use serde::{Deserialize, Serialize};
 use staking::state::STAKERS;
 
 use super::*;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ResponsePayload {
+    pub dr_id:  String,
+    pub height: u64,
+}
 
 impl ExecuteHandler for execute::post_request::Execute {
     /// Posts a data request to the pool
@@ -29,7 +36,10 @@ impl ExecuteHandler for execute::post_request::Execute {
         let hex_dr_id = dr_id.to_hex();
         let res = Response::new()
             .add_attribute("action", "post_data_request")
-            .set_data(to_json_binary(&hex_dr_id)?)
+            .set_data(to_json_binary(&ResponsePayload {
+                dr_id:  hex_dr_id.clone(),
+                height: env.block.height,
+            })?)
             .add_event(Event::new("seda-data-request").add_attributes([
                 ("dr_id", hex_dr_id.clone()),
                 ("exec_program_id", self.posted_dr.exec_program_id.clone()),

--- a/contract/src/msgs/data_requests/test_helpers.rs
+++ b/contract/src/msgs/data_requests/test_helpers.rs
@@ -8,7 +8,7 @@ use super::{
     msgs::data_requests::{execute, query, sudo},
     *,
 };
-use crate::{TestExecutor, TestInfo};
+use crate::{msgs::data_requests::execute::post_request::ResponsePayload, TestExecutor, TestInfo};
 
 pub fn calculate_dr_id_and_args(nonce: u128, replication_factor: u16) -> PostDataRequestArgs {
     let exec_program_id = nonce.to_string().hash().to_hex();
@@ -109,7 +109,12 @@ impl TestInfo {
         // set the chain height... will effect the height in the dr for us to sign.
         self.set_block_height(env_height);
         // someone posts a data request
-        self.execute(sender, &msg)
+        let res: ResponsePayload = self.execute(sender, &msg)?;
+        assert_eq!(
+            env_height, res.height,
+            "chain height does not match data request height"
+        );
+        Ok(res.dr_id)
     }
 
     #[track_caller]

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -63,7 +63,7 @@ impl TryFrom<&[u8]> for PublicKey {
     }
 }
 
-impl<'a> PrimaryKey<'a> for PublicKey {
+impl PrimaryKey<'_> for PublicKey {
     type Prefix = ();
     type SubPrefix = ();
     type Suffix = ();


### PR DESCRIPTION
## Motivation

Allow solvers to accurately track the DR that they posted and reduce the risk of forwarding an old result.

## Explanation of Changes

Updated the test utility to verify the response and forward just the `dr_id` so we don't have to change all the tests.

## Testing

Tests still pass.

## Related PRs and Issues

N.A.
