### PR TITLE
Feat/pausable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,8 +956,8 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "0.5.0"
-source = "git+https://github.com/sedaprotocol/seda-common-rs.git?tag=v0.5.0#7810fad666ee1992e3353928da7550ec5b70ad51"
+version = "0.5.1"
+source = "git+https://github.com/sedaprotocol/seda-common-rs.git?tag=v0.5.1#2a3551a8fd8c1cd51da69cf82b88840012bd1847"
 dependencies = [
  "base64",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ lazy_static = "1.4"
 libfuzzer-sys = "0.4"
 rand = "0.8"
 schemars = { version = "0.8", features = ["semver"] }
-seda-common = { git = "https://github.com/sedaprotocol/seda-common-rs.git", tag = "v0.5.0" }
+seda-common = { git = "https://github.com/sedaprotocol/seda-common-rs.git", tag = "v0.5.1" }
 # leaving this in to make local development easier
 # seda-common = { path = "../seda-common-rs/crates/common" }
 semver = { version = "1.0", features = ["serde"] }

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -72,6 +72,10 @@ pub enum ContractError {
     InvalidHashLength(usize),
     #[error("Invalid public key length `{0}` expected 33 bytes")]
     InvalidPublicKeyLength(usize),
+    #[error("Contract paused: cannot perform operation `{0}`")]
+    ContractPaused(String),
+    #[error("Contract not paused: cannot unpause")]
+    ContractNotPaused,
 }
 
 #[cfg(test)]

--- a/contract/src/msgs/owner/execute/mod.rs
+++ b/contract/src/msgs/owner/execute/mod.rs
@@ -7,8 +7,10 @@ use super::{
 
 pub(in crate::msgs::owner) mod accept_ownership;
 pub(in crate::msgs::owner) mod add_to_allowlist;
+pub mod pause;
 pub(in crate::msgs::owner) mod remove_from_allowlist;
 pub(in crate::msgs::owner) mod transfer_ownership;
+pub mod unpause;
 
 impl ExecuteHandler for ExecuteMsg {
     fn execute(self, deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
@@ -17,6 +19,8 @@ impl ExecuteHandler for ExecuteMsg {
             ExecuteMsg::AcceptOwnership(msg) => msg.execute(deps, env, info),
             ExecuteMsg::AddToAllowlist(msg) => msg.execute(deps, env, info),
             ExecuteMsg::RemoveFromAllowlist(msg) => msg.execute(deps, env, info),
+            ExecuteMsg::Pause(msg) => msg.execute(deps, env, info),
+            ExecuteMsg::Unpause(msg) => msg.execute(deps, env, info),
         }
     }
 }

--- a/contract/src/msgs/owner/execute/pause.rs
+++ b/contract/src/msgs/owner/execute/pause.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
+use seda_common::msgs::owner::execute;
+
+use crate::{
+    contract::CONTRACT_VERSION,
+    error::ContractError,
+    msgs::{owner::state::OWNER, ExecuteHandler},
+    state::PAUSED,
+};
+
+impl ExecuteHandler for execute::pause::Execute {
+    fn execute(self, deps: DepsMut, _: Env, info: MessageInfo) -> Result<Response, ContractError> {
+        // require the sender to be the OWNER
+        let owner = OWNER.load(deps.storage)?;
+        if info.sender != owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let paused = PAUSED.load(deps.storage)?;
+        if paused {
+            return Err(ContractError::ContractPaused("pause".to_string()));
+        }
+
+        PAUSED.save(deps.storage, &true)?;
+
+        Ok(Response::new().add_events([Event::new("seda-pause-contract")
+            .add_attributes([("version", CONTRACT_VERSION.to_string()), ("paused", true.to_string())])]))
+    }
+}

--- a/contract/src/msgs/owner/execute/unpause.rs
+++ b/contract/src/msgs/owner/execute/unpause.rs
@@ -1,0 +1,29 @@
+use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
+use seda_common::msgs::owner::execute;
+
+use crate::{
+    contract::CONTRACT_VERSION,
+    error::ContractError,
+    msgs::{owner::state::OWNER, ExecuteHandler},
+    state::PAUSED,
+};
+
+impl ExecuteHandler for execute::unpause::Execute {
+    fn execute(self, deps: DepsMut, _: Env, info: MessageInfo) -> Result<Response, ContractError> {
+        // require the sender to be the OWNER
+        let owner = OWNER.load(deps.storage)?;
+        if info.sender != owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let paused = PAUSED.load(deps.storage)?;
+        if !paused {
+            return Err(ContractError::ContractNotPaused);
+        }
+
+        PAUSED.save(deps.storage, &false)?;
+
+        Ok(Response::new().add_events([Event::new("seda-pause-contract")
+            .add_attributes([("version", CONTRACT_VERSION.to_string()), ("paused", false.to_string())])]))
+    }
+}

--- a/contract/src/msgs/owner/query.rs
+++ b/contract/src/msgs/owner/query.rs
@@ -3,12 +3,14 @@ use super::{
     state::{OWNER, PENDING_OWNER},
     *,
 };
+use crate::state::PAUSED;
 
 impl QueryHandler for QueryMsg {
     fn query(self, deps: Deps, _env: Env) -> Result<Binary, ContractError> {
         let binary = match self {
             QueryMsg::GetOwner {} => to_json_binary(&OWNER.load(deps.storage)?)?,
             QueryMsg::GetPendingOwner {} => to_json_binary(&PENDING_OWNER.load(deps.storage)?)?,
+            QueryMsg::IsPaused {} => to_json_binary(&PAUSED.load(deps.storage)?)?,
         };
 
         Ok(binary)

--- a/contract/src/msgs/owner/test_helpers.rs
+++ b/contract/src/msgs/owner/test_helpers.rs
@@ -49,4 +49,21 @@ impl TestInfo {
 
         self.execute(sender, &msg)
     }
+
+    #[track_caller]
+    pub fn pause(&mut self, sender: &TestExecutor) -> Result<(), ContractError> {
+        let msg = execute::pause::Execute {}.into();
+        self.execute(sender, &msg)
+    }
+
+    #[track_caller]
+    pub fn unpause(&mut self, sender: &TestExecutor) -> Result<(), ContractError> {
+        let msg = execute::unpause::Execute {}.into();
+        self.execute(sender, &msg)
+    }
+
+    #[track_caller]
+    pub fn is_paused(&self) -> bool {
+        self.query(query::QueryMsg::IsPaused {}).unwrap()
+    }
 }

--- a/contract/src/msgs/owner/tests.rs
+++ b/contract/src/msgs/owner/tests.rs
@@ -1,4 +1,4 @@
-use seda_common::msgs::staking::StakingConfig;
+use seda_common::msgs::{data_requests::DataRequestStatus, staking::StakingConfig};
 
 use crate::{error::ContractError, TestInfo};
 
@@ -127,4 +127,58 @@ pub fn allowlist_works() {
 
     // now alice can register a data request executor
     test_info.stake(&mut alice, None, 100).unwrap();
+}
+
+#[test]
+pub fn pause_works() {
+    let mut test_info = TestInfo::init();
+
+    // check that the contract is not paused
+    assert!(!test_info.is_paused());
+
+    // pause the contract
+    test_info.pause(&test_info.creator()).unwrap();
+    assert!(test_info.is_paused());
+
+    // double pause leaves errors
+    let err = test_info.pause(&test_info.creator()).unwrap_err();
+    assert!(err.to_string().contains("Contract paused"));
+
+    // check that sudo messages are paused
+    assert!(test_info
+        .remove_data_request("Doesn't matter".to_string(), vec![])
+        .is_err());
+
+    // unpause the contract
+    test_info.unpause(&test_info.creator()).unwrap();
+    assert!(!test_info.is_paused());
+
+    // double unpause leaves errors
+    let err = test_info.unpause(&test_info.creator()).unwrap_err();
+    assert!(err.to_string().contains("Contract not paused"));
+}
+
+#[test]
+pub fn paused_contract_returns_empty_dr_query_by_status() {
+    let mut test_info = TestInfo::init();
+    let mut anyone = test_info.new_executor("anyone", Some(22));
+    anyone.stake(&mut test_info, 1).unwrap();
+
+    // post a data request
+    let dr = crate::msgs::data_requests::test::test_helpers::calculate_dr_id_and_args(1, 1);
+    let _dr_id = test_info
+        .post_data_request(&mut anyone, dr, vec![], vec![], 2, None)
+        .unwrap();
+
+    let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
+    assert_eq!(1, drs.len());
+
+    test_info.pause(&test_info.creator()).unwrap();
+    assert!(test_info.is_paused());
+
+    let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
+    assert_eq!(0, drs.len());
+
+    test_info.unpause(&test_info.creator()).unwrap();
+    assert!(!test_info.is_paused());
 }

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -3,6 +3,9 @@ use cw_storage_plus::{Item, Map};
 
 use crate::types::PublicKey;
 
+/// Flag to indicate if the contract is paused.
+pub const PAUSED: Item<bool> = Item::new("paused");
+
 /// Token denom used for staking (e.g., `aseda`).
 pub const TOKEN: Item<String> = Item::new("token");
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Pausable behavior adds safety in case something goes wrong.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Adds pause and unpause exec methods, checking if you are owner first.
These methods just always pause/unpause rather than erroring if they are already in that state. Let me know if this should be changed.

Querying dr's by status returns an empty list when contract is paused.
Sudo methods do not work while the contract is paused.

We also have a query to check the paused state of the contract.
Was unsure if this should pause the other DR queries/executions?

I didn't update the version in the toml yet, because was unsure if this dictates a minor or patch change :x

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

New tests added.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Waiting for https://github.com/sedaprotocol/seda-common-rs/pull/39 to be merged first.

Closes #256.
