### PR TITLE
fix: pause and allowlist discrepancies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "0.5.2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "0.5.2"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/msgs/data_requests/execute/mod.rs
+++ b/contract/src/msgs/data_requests/execute/mod.rs
@@ -2,6 +2,7 @@ use super::{
     msgs::data_requests::execute::{self, ExecuteMsg},
     *,
 };
+use crate::state::PAUSED;
 
 pub(in crate::msgs::data_requests) mod commit_result;
 pub(crate) mod dr_events;
@@ -11,6 +12,13 @@ pub(in crate::msgs::data_requests) mod set_timeout_config;
 
 impl ExecuteHandler for ExecuteMsg {
     fn execute(self, deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+        // setting the timeout config is an owner operation and should not be paused
+        if PAUSED.load(deps.storage)? && !matches!(self, ExecuteMsg::SetTimeoutConfig(_)) {
+            return Err(ContractError::ContractPaused(
+                "data request execute messages".to_string(),
+            ));
+        }
+
         match self {
             ExecuteMsg::CommitDataResult(msg) => msg.execute(deps, env, info),
             ExecuteMsg::PostDataRequest(msg) => msg.execute(deps, env, info),

--- a/contract/src/msgs/data_requests/tests.rs
+++ b/contract/src/msgs/data_requests/tests.rs
@@ -1421,3 +1421,87 @@ fn only_owner_can_change_timeout_config() {
     let alice = test_info.new_executor("alice", Some(2));
     test_info.set_timeout_config(&alice, timeout_config).unwrap();
 }
+
+#[test]
+pub fn paused_contract_returns_empty_dr_query_by_status() {
+    let mut test_info = TestInfo::init();
+    let mut anyone = test_info.new_executor("anyone", Some(22));
+    anyone.stake(&mut test_info, 1).unwrap();
+
+    // post a data request
+    let dr = crate::msgs::data_requests::test::test_helpers::calculate_dr_id_and_args(1, 1);
+    let _dr_id = test_info
+        .post_data_request(&mut anyone, dr, vec![], vec![], 2, None)
+        .unwrap();
+
+    let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
+    assert_eq!(1, drs.len());
+
+    test_info.pause(&test_info.creator()).unwrap();
+    assert!(test_info.is_paused());
+
+    let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
+    assert_eq!(0, drs.len());
+
+    test_info.unpause(&test_info.creator()).unwrap();
+    assert!(!test_info.is_paused());
+}
+
+#[test]
+pub fn execute_messages_get_paused() {
+    let mut test_info = TestInfo::init();
+    let mut alice = test_info.new_executor("alice", Some(1000));
+
+    // register alice as a staker
+    alice.stake(&mut test_info, 1).unwrap();
+
+    // post a data request we can commit on
+    let dr = crate::msgs::data_requests::test::test_helpers::calculate_dr_id_and_args(1, 1);
+    let dr_id_committable = test_info
+        .post_data_request(&mut alice, dr, vec![], vec![], 1, None)
+        .unwrap();
+
+    // post a data request we can reveal on
+    let dr = crate::msgs::data_requests::test::test_helpers::calculate_dr_id_and_args(2, 1);
+    let dr_id_revealable = test_info
+        .post_data_request(&mut alice, dr, vec![], vec![], 1, None)
+        .unwrap();
+    // commit on it
+    let alice_reveal = RevealBody {
+        id:                dr_id_revealable.clone(),
+        salt:              alice.salt(),
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![],
+    };
+    test_info
+        .commit_result(&alice, &dr_id_revealable, alice_reveal.try_hash().unwrap())
+        .unwrap();
+
+    // pause the contract
+    test_info.pause(&test_info.creator()).unwrap();
+    assert!(test_info.is_paused());
+
+    // try to post another data request
+    let dr = crate::msgs::data_requests::test::test_helpers::calculate_dr_id_and_args(3, 1);
+    let res = test_info.post_data_request(&mut alice, dr, vec![], vec![], 1, None);
+    assert!(res.is_err_and(|e| e.to_string().contains("pause")));
+
+    // try to commit a data result
+    let res = test_info.commit_result(&alice, &dr_id_committable, alice_reveal.try_hash().unwrap());
+    assert!(res.is_err_and(|e| e.to_string().contains("pause")));
+
+    // try to reveal a data result
+    let res = test_info.reveal_result(&alice, &dr_id_revealable, alice_reveal.clone());
+    assert!(res.is_err_and(|e| e.to_string().contains("pause")));
+
+    // can still change the timeout config
+    let timeout_config = TimeoutConfig {
+        commit_timeout_in_blocks: 1,
+        reveal_timeout_in_blocks: 1,
+    };
+    test_info
+        .set_timeout_config(&test_info.creator(), timeout_config)
+        .unwrap();
+}

--- a/contract/src/msgs/owner/execute/remove_from_allowlist.rs
+++ b/contract/src/msgs/owner/execute/remove_from_allowlist.rs
@@ -12,7 +12,6 @@ impl ExecuteHandler for execute::remove_from_allowlist::Execute {
 
         // we need to remove the address from the allowlist
         let public_key = PublicKey::from_hex_str(&self.public_key)?;
-        ALLOWLIST.remove(deps.storage, &public_key);
 
         if let Some(staker) = STAKERS.may_get_staker(deps.storage, &public_key)? {
             // we move their staked tokens to the pending withdrawal
@@ -20,13 +19,14 @@ impl ExecuteHandler for execute::remove_from_allowlist::Execute {
             let staker = Staker {
                 memo:                      staker.memo,
                 tokens_staked:             Uint128::new(0),
-                tokens_pending_withdrawal: staker.tokens_staked,
+                tokens_pending_withdrawal: staker.tokens_staked.checked_add(staker.tokens_pending_withdrawal)?,
             };
 
             STAKERS.update(deps.storage, public_key.clone(), &staker)?;
         }
 
-        // Move
+        // do this at the end in case we fail above
+        ALLOWLIST.remove(deps.storage, &public_key);
 
         Ok(Response::new()
             .add_attribute("action", "remove-from-allowlist")

--- a/contract/src/msgs/owner/execute/remove_from_allowlist.rs
+++ b/contract/src/msgs/owner/execute/remove_from_allowlist.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::msgs::staking::state::STAKERS;
 
 impl ExecuteHandler for execute::remove_from_allowlist::Execute {
     /// Remove a `Secp256k1PublicKey` to the allow list
@@ -9,9 +10,23 @@ impl ExecuteHandler for execute::remove_from_allowlist::Execute {
             return Err(ContractError::NotOwner);
         }
 
-        // remove the address from the allowlist
+        // we need to remove the address from the allowlist
         let public_key = PublicKey::from_hex_str(&self.public_key)?;
         ALLOWLIST.remove(deps.storage, &public_key);
+
+        if let Some(staker) = STAKERS.may_get_staker(deps.storage, &public_key)? {
+            // we move their staked tokens to the pending withdrawal
+            // so that they can withdraw them and no longer be a staker
+            let staker = Staker {
+                memo:                      staker.memo,
+                tokens_staked:             Uint128::new(0),
+                tokens_pending_withdrawal: staker.tokens_staked,
+            };
+
+            STAKERS.update(deps.storage, public_key.clone(), &staker)?;
+        }
+
+        // Move
 
         Ok(Response::new()
             .add_attribute("action", "remove-from-allowlist")

--- a/contract/src/msgs/owner/tests.rs
+++ b/contract/src/msgs/owner/tests.rs
@@ -1,4 +1,4 @@
-use seda_common::msgs::{data_requests::DataRequestStatus, staking::StakingConfig};
+use seda_common::msgs::staking::StakingConfig;
 
 use crate::{error::ContractError, TestInfo};
 
@@ -156,29 +156,4 @@ pub fn pause_works() {
     // double unpause leaves errors
     let err = test_info.unpause(&test_info.creator()).unwrap_err();
     assert!(err.to_string().contains("Contract not paused"));
-}
-
-#[test]
-pub fn paused_contract_returns_empty_dr_query_by_status() {
-    let mut test_info = TestInfo::init();
-    let mut anyone = test_info.new_executor("anyone", Some(22));
-    anyone.stake(&mut test_info, 1).unwrap();
-
-    // post a data request
-    let dr = crate::msgs::data_requests::test::test_helpers::calculate_dr_id_and_args(1, 1);
-    let _dr_id = test_info
-        .post_data_request(&mut anyone, dr, vec![], vec![], 2, None)
-        .unwrap();
-
-    let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
-    assert_eq!(1, drs.len());
-
-    test_info.pause(&test_info.creator()).unwrap();
-    assert!(test_info.is_paused());
-
-    let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
-    assert_eq!(0, drs.len());
-
-    test_info.unpause(&test_info.creator()).unwrap();
-    assert!(!test_info.is_paused());
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So that pausing prevents execution messages in case there are contract problems.
And that removing someone from the allowlist no longer makes them an executor.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

In the `mod.rs` file of both the `data_request` and `staking` execute modules now check if the contract is paused. If it is we don't allow the execute messages to go through, with the exception of their respective owner messages.

Also did the allowlist changes in this PR.
So removing someone from the allowlist now moves their staked tokens to the pending withdraw.
## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Adds tests to check that.
I did move the one test that was in owner tests to data request test as it makes more sense to be there.

Added tests for the allowlist stuff as well.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
