### PR TITLE
chore: no longer return empty drs when paused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "0.5.6"
+version = "0.5.7"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -93,10 +93,6 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> R
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn sudo(deps: DepsMut, env: Env, sudo: SudoMsg) -> Result<Response, ContractError> {
-    if PAUSED.load(deps.storage)? {
-        return Err(ContractError::ContractPaused("sudo messages".to_string()));
-    }
-
     sudo.sudo(deps, env)
 }
 

--- a/contract/src/msgs/data_requests/query.rs
+++ b/contract/src/msgs/data_requests/query.rs
@@ -55,13 +55,6 @@ impl QueryHandler for QueryMsg {
                 let reveals = dr.map(|dr| dr.reveals).unwrap_or_default();
                 to_json_binary(&reveals)?
             }
-            QueryMsg::GetDataRequestsByStatus { .. } if contract_paused => {
-                let response = GetDataRequestsByStatusResponse {
-                    is_paused:     contract_paused,
-                    data_requests: Vec::with_capacity(0),
-                };
-                to_json_binary(&response)?
-            }
             QueryMsg::GetDataRequestsByStatus { status, offset, limit } => {
                 let response = GetDataRequestsByStatusResponse {
                     is_paused:     contract_paused,

--- a/contract/src/msgs/data_requests/tests.rs
+++ b/contract/src/msgs/data_requests/tests.rs
@@ -1457,7 +1457,7 @@ fn only_owner_can_change_timeout_config() {
 }
 
 #[test]
-pub fn paused_contract_returns_empty_dr_query_by_status() {
+pub fn paused_contract_returns_pause_property_dr_query_by_status() {
     let mut test_info = TestInfo::init();
     let mut anyone = test_info.new_executor("anyone", Some(22));
     anyone.stake(&mut test_info, 1).unwrap();
@@ -1477,7 +1477,7 @@ pub fn paused_contract_returns_empty_dr_query_by_status() {
 
     let drs = test_info.get_data_requests_by_status(DataRequestStatus::Committing, 0, 10);
     assert!(drs.is_paused);
-    assert_eq!(0, drs.data_requests.len());
+    assert_eq!(1, drs.data_requests.len());
 
     test_info.unpause(&test_info.creator()).unwrap();
     assert!(!test_info.is_paused());


### PR DESCRIPTION
Since we now always continue the flow and that way tally can always resolve
