### PR TITLE
test: unstaking edge cases

### DIFF
--- a/contract/src/test_utils.rs
+++ b/contract/src/test_utils.rs
@@ -276,6 +276,11 @@ impl TestExecutor {
         test_info.stake(self, None, amount)?;
         Ok(())
     }
+
+    pub fn unstake(&mut self, test_info: &mut TestInfo, amount: u128) -> Result<(), ContractError> {
+        test_info.unstake(self, amount)?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To add some tests for edge cases.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Adds tests for:
- staker unstaking before being rewarded
- data request running out of funds
- a user can reveal after unstaking

The only things I noticed that might be worth double checking are:
- A staker can commit and reveal on their own data requests. The math for available executors also accounts for this. But this seems fine to me? There doesn't seem like there would be any conflict of interests for this.
- In remove data requests we don't check that the data request being removed is in the tally state. We simply trust the DRs the chain passes.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tests pass.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
