### PR TITLE
feat: paginated executors query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,8 +1013,8 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "0.5.3"
-source = "git+https://github.com/sedaprotocol/seda-common-rs.git?tag=v0.5.3#ade80eb8344ad8eba773e37ff5edf1ef52828a07"
+version = "0.5.4"
+source = "git+https://github.com/sedaprotocol/seda-common-rs.git?tag=v0.5.4#661ed0abe98ea87f0fe24c646f2968abdd662013"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ lazy_static = "1.4"
 libfuzzer-sys = "0.4"
 rand = "0.9"
 schemars = { version = "0.8", features = ["semver"] }
-seda-common = { git = "https://github.com/sedaprotocol/seda-common-rs.git", tag = "v0.5.3" }
+seda-common = { git = "https://github.com/sedaprotocol/seda-common-rs.git", tag = "v0.5.4" }
 # leaving this in to make local development easier
 # seda-common = { path = "../seda-common-rs/crates/common" }
 semver = { version = "1.0", features = ["serde"] }

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "0.5.9"
+version = "0.5.10"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/msgs/staking/test_helpers.rs
+++ b/contract/src/msgs/staking/test_helpers.rs
@@ -1,3 +1,5 @@
+use seda_common::msgs::staking::GetExecutorsResponse;
+
 use super::{
     msgs::staking::{execute, query},
     *,
@@ -154,6 +156,13 @@ impl TestAccount {
             .query(query::QueryMsg::GetAccountSeq {
                 public_key: self.pub_key_hex(),
             })
+            .unwrap()
+    }
+
+    #[track_caller]
+    pub fn query_executors(&self, offset: u32, limit: u32) -> GetExecutorsResponse {
+        self.test_info
+            .query(query::QueryMsg::GetExecutors { offset, limit })
             .unwrap()
     }
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To be able to query executors in a paginated fashion.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Imports the new query and result from common.
Uses the `EnumerableSet` to grab the users, then maps them to their information.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Added new tests to check behavior.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

~~Blocked by https://github.com/sedaprotocol/seda-common-rs/pull/42 being merged and updating the toml.~~
Closes #266.
