### PR TITLE
Fix: commit reveal

### DIFF
--- a/common/src/msgs/data_requests/execute/commit_result.rs
+++ b/common/src/msgs/data_requests/execute/commit_result.rs
@@ -6,6 +6,7 @@ use crate::{error::Result, types::*};
 pub struct Execute {
     pub dr_id:      String,
     pub commitment: String,
+    /// A hash of the reveal message, not just the reveal body
     pub public_key: String,
     pub proof:      String,
 }

--- a/common/src/msgs/data_requests/execute_tests.rs
+++ b/common/src/msgs/data_requests/execute_tests.rs
@@ -121,8 +121,8 @@ fn json_reveal_result() {
     let reveal: Bytes = "reveal".as_bytes().into();
 
     let reveal_body = RevealBody {
-        id: "dr_id".to_string(),
-        salt: "salt".to_string(),
+        dr_id: "dr_id".to_string(),
+        dr_block_height: 1,
         exit_code: 0,
         gas_used,
         reveal: reveal.clone(),
@@ -130,10 +130,9 @@ fn json_reveal_result() {
     };
     let expected_json = json!({
       "reveal_data_result": {
-        "dr_id": "dr_id",
         "reveal_body": {
-          "id": "dr_id",
-          "salt": "salt",
+          "dr_id": "dr_id",
+          "dr_block_height": 1,
           "exit_code": 0,
           "gas_used": gas_used,
           "reveal": reveal,
@@ -146,7 +145,6 @@ fn json_reveal_result() {
       }
     });
     let msg: msgs::ExecuteMsg = reveal_result::Execute {
-        dr_id: "dr_id".to_string(),
         reveal_body,
         public_key: "public_key".to_string(),
         proof: "proof".to_string(),

--- a/common/src/msgs/data_requests/types.rs
+++ b/common/src/msgs/data_requests/types.rs
@@ -103,8 +103,8 @@ impl DataRequest {
 #[cfg_attr(not(feature = "cosmwasm"), derive(Serialize, Deserialize, Clone, Debug, PartialEq))]
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub struct RevealBody {
-    pub id:                String,
-    pub salt:              String,
+    pub dr_id:             String,
+    pub dr_block_height:   u64,
     pub exit_code:         u8,
     pub gas_used:          u64,
     pub reveal:            Bytes,
@@ -121,8 +121,8 @@ impl TryHashSelf for RevealBody {
         let reveal_hash = reveal_hasher.finalize();
 
         let mut hasher = Keccak256::new();
-        hasher.update(hex::decode(&self.id)?);
-        hasher.update(&self.salt);
+        hasher.update(hex::decode(&self.dr_id)?);
+        hasher.update(self.dr_block_height.to_be_bytes());
         hasher.update(self.exit_code.to_be_bytes());
         hasher.update(self.gas_used.to_be_bytes());
         hasher.update(reveal_hash);

--- a/common/src/msgs/data_requests/types_tests.rs
+++ b/common/src/msgs/data_requests/types_tests.rs
@@ -110,8 +110,8 @@ fn json_data_request() {
 
 #[test]
 fn json_reveal_body() {
-    let id = "id".to_string();
-    let salt = "salt".to_string();
+    let dr_id = "id".to_string();
+    let dr_block_height = 1;
     let exit_code = 0;
     let gas_used = 1;
     #[cfg(not(feature = "cosmwasm"))]
@@ -121,8 +121,8 @@ fn json_reveal_body() {
     let proxy_public_keys = vec!["key1".to_string(), "key2".to_string()];
 
     let expected_json = json!({
-      "id": id,
-      "salt": salt,
+      "dr_id": dr_id,
+      "dr_block_height": dr_block_height,
       "exit_code": exit_code,
       "gas_used": gas_used,
       "reveal": reveal,
@@ -130,8 +130,8 @@ fn json_reveal_body() {
     });
 
     let msg = RevealBody {
-        id,
-        salt,
+        dr_id,
+        dr_block_height,
         exit_code,
         gas_used,
         reveal,

--- a/contract/src/msgs/data_requests/tests/query_dr_status.rs
+++ b/contract/src/msgs/data_requests/tests/query_dr_status.rs
@@ -4,7 +4,7 @@ use seda_common::{
         DataRequestStatus,
         RevealBody,
     },
-    types::{HashSelf, TryHashSelf},
+    types::HashSelf,
 };
 
 use crate::{msgs::data_requests::test_helpers, TestInfo};
@@ -90,20 +90,21 @@ fn works_with_more_drs_in_pool() {
         let dr = test_helpers::calculate_dr_id_and_args(i, 1);
         let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
         let alice_reveal = RevealBody {
-            id:                dr_id.clone(),
-            salt:              alice.salt(),
+            dr_id:             dr_id.clone(),
+            dr_block_height:   1,
             reveal:            "10".hash().into(),
             gas_used:          0,
             exit_code:         0,
             proxy_public_keys: vec![],
         };
+        let alice_reveal_message = alice.create_reveal_message(alice_reveal);
 
         if i < 15 {
-            alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+            alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
         }
 
         if i < 3 {
-            alice.reveal_result(&dr_id, alice_reveal.clone()).unwrap();
+            alice.reveal_result(alice_reveal_message).unwrap();
         }
     }
 
@@ -141,16 +142,17 @@ fn works_with_many_more_drs_in_pool() {
         let dr = test_helpers::calculate_dr_id_and_args(i, 1);
         let dr_id = alice.post_data_request(dr.clone(), vec![], vec![], 1, None).unwrap();
         let alice_reveal = RevealBody {
-            id:                dr_id.clone(),
-            salt:              alice.salt(),
+            dr_id:             dr_id.clone(),
+            dr_block_height:   1,
             reveal:            "10".hash().into(),
             gas_used:          0,
             exit_code:         0,
             proxy_public_keys: vec![],
         };
+        let alice_reveal_message = alice.create_reveal_message(alice_reveal);
 
         if i % 2 == 0 {
-            alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+            alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
             alice.get_data_requests_by_status(DataRequestStatus::Committing, 0, 100);
 
@@ -188,15 +190,16 @@ fn works_with_many_more_drs_in_pool() {
     {
         if i % 4 == 0 {
             let alice_reveal = RevealBody {
-                id:                request.id.clone(),
-                salt:              alice.salt(),
+                dr_id:             request.id.clone(),
+                dr_block_height:   1,
                 reveal:            "10".hash().into(),
                 gas_used:          0,
                 exit_code:         0,
                 proxy_public_keys: vec![],
             };
+            let alice_reveal_message = alice.create_reveal_message(alice_reveal);
 
-            alice.reveal_result(&request.id, alice_reveal.clone()).unwrap();
+            alice.reveal_result(alice_reveal_message).unwrap();
 
             let dr = test_helpers::calculate_dr_id_and_args(i as u128 + 10000, 1);
             alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();

--- a/contract/src/msgs/data_requests/tests/reveal_dr.rs
+++ b/contract/src/msgs/data_requests/tests/reveal_dr.rs
@@ -1,6 +1,6 @@
 use seda_common::{
     msgs::data_requests::{DataRequestStatus, RevealBody},
-    types::{HashSelf, ToHexStr, TryHashSelf},
+    types::{HashSelf, ToHexStr},
 };
 
 use crate::{msgs::data_requests::test_helpers, new_public_key, TestInfo};
@@ -17,14 +17,15 @@ fn works() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     let query_result = bob.can_executor_reveal(&dr_id);
     assert!(
@@ -34,19 +35,20 @@ fn works() {
 
     // bob also commits
     let bob_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "20".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    bob.commit_result(&dr_id, bob_reveal.try_hash().unwrap()).unwrap();
+    let bob_reveal_message = bob.create_reveal_message(bob_reveal);
+    bob.commit_result(&dr_id, &bob_reveal_message).unwrap();
 
     let query_result = alice.can_executor_reveal(&dr_id);
     assert!(query_result, "executor should be able to reveal");
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 
     let revealing = alice.get_data_requests_by_status(DataRequestStatus::Revealing, 0, 10);
     assert!(!revealing.is_paused);
@@ -69,17 +71,18 @@ fn works_with_proxies() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: proxies,
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 
     let tallying = alice.get_data_requests_by_status(DataRequestStatus::Tallying, 0, 10);
     assert!(!tallying.is_paused);
@@ -103,47 +106,18 @@ fn fails_with_invalid_proxies_public_keys() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: proxies.clone(),
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
-}
-
-#[test]
-#[should_panic(expected = "RevealMismatch")]
-fn fails_when_body_is_missing_proxies() {
-    let test_info = TestInfo::init();
-    let alice = test_info.new_executor("alice", 22, 1);
-
-    // post a data request
-    let dr = test_helpers::calculate_dr_id_and_args(1, 1);
-    let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
-
-    let (_, proxy1) = new_public_key();
-    let (_, proxy2) = new_public_key();
-    let proxies = vec![proxy1.to_hex(), proxy2.to_hex()];
-
-    // alice commits a data result
-    let mut alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
-        reveal:            "10".hash().into(),
-        gas_used:          0,
-        exit_code:         0,
-        proxy_public_keys: proxies,
-    };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
-
-    // alice reveals
-    alice_reveal.proxy_public_keys = vec![];
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 }
 
 #[test]
@@ -159,14 +133,15 @@ fn fails_if_not_in_reveal_status() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     let query_result = bob.can_executor_reveal(&dr_id);
     assert!(
@@ -175,7 +150,7 @@ fn fails_if_not_in_reveal_status() {
     );
 
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 }
 
 #[test]
@@ -190,20 +165,21 @@ fn fails_if_timed_out() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // set the block height to be later than the timeout
     test_info.set_block_height(11);
 
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 }
 
 #[test]
@@ -218,14 +194,15 @@ fn fails_on_expired_dr() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // set the block height to be later than the timeout
     test_info.set_block_height(11);
@@ -234,7 +211,7 @@ fn fails_on_expired_dr() {
     test_info.creator().expire_data_requests().unwrap();
 
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 }
 
 #[test]
@@ -249,28 +226,30 @@ fn fails_if_user_did_not_commit() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // bob also commits
     let bob = test_info.new_executor("bob", 2, 1);
     let bob_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "20".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
+    let bob_reveal_message = bob.create_reveal_message(bob_reveal);
 
     // bob reveals
-    bob.reveal_result(&dr_id, bob_reveal).unwrap();
+    bob.reveal_result(bob_reveal_message).unwrap();
 
     let revealing = alice.get_data_requests_by_status(DataRequestStatus::Revealing, 0, 10);
     assert!(!revealing.is_paused);
@@ -291,31 +270,33 @@ fn fails_on_double_reveal() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // bob also commits
     let bob_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "20".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    bob.commit_result(&dr_id, bob_reveal.try_hash().unwrap()).unwrap();
+    let bob_reveal_message = bob.create_reveal_message(bob_reveal);
+    bob.commit_result(&dr_id, &bob_reveal_message).unwrap();
 
     // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal.clone()).unwrap();
+    alice.reveal_result(alice_reveal_message.clone()).unwrap();
 
     // alice reveals again
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 }
 
 #[test]
@@ -331,48 +312,81 @@ fn fails_if_does_not_match_commitment() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice
-        .commit_result(
-            &dr_id,
-            RevealBody {
-                id:                dr_id.clone(),
-                salt:              alice.salt(),
-                reveal:            "11".hash().into(),
-                gas_used:          0,
-                exit_code:         0,
-                proxy_public_keys: vec![],
-            }
-            .try_hash()
-            .unwrap(),
-        )
-        .unwrap();
+    let alice_reveal_message_commitment = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message_commitment).unwrap();
 
     // bob also commits
-
     let bob_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "20".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    bob.commit_result(&dr_id, bob_reveal.try_hash().unwrap()).unwrap();
+    let bob_reveal_message = bob.create_reveal_message(bob_reveal);
+    bob.commit_result(&dr_id, &bob_reveal_message).unwrap();
 
-    // alice reveals
-    alice.reveal_result(&dr_id, alice_reveal).unwrap();
+    // alice reveals a different message
+    let alice_reveal2 = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "30".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![],
+    };
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal2);
+    alice.reveal_result(alice_reveal_message).unwrap();
 
     let revealing = alice.get_data_requests_by_status(DataRequestStatus::Revealing, 0, 10);
     assert!(!revealing.is_paused);
     assert_eq!(1, revealing.data_requests.len());
     assert!(revealing.data_requests.iter().any(|r| r.id == dr_id));
+}
+
+#[test]
+#[should_panic(expected = "RevealMismatch")]
+fn fails_if_proxy_public_keys_changed() {
+    let test_info = TestInfo::init();
+    let alice = test_info.new_executor("alice", 22, 1);
+
+    // post a data request
+    let dr = test_helpers::calculate_dr_id_and_args(1, 1);
+    let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
+
+    // alice commits a data result
+    let (_, proxy1) = new_public_key();
+    let alice_reveal = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![proxy1.to_hex()],
+    };
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
+
+    // alice reveals with an additional proxy public key
+    let (_, proxy2) = new_public_key();
+    let alice_reveal2 = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![proxy1.to_hex(), proxy2.to_hex()],
+    };
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal2);
+    alice.reveal_result(alice_reveal_message).unwrap();
 }
 
 #[test]
@@ -386,24 +400,82 @@ fn works_after_unstaking() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // alice unstakes after committing
     alice.unstake(1).unwrap();
 
     // alice should still be able to reveal
-    alice.reveal_result(&dr_id, alice_reveal.clone()).unwrap();
+    alice.reveal_result(alice_reveal_message).unwrap();
 
     // verify the request moved to tallying state
     let tallying = alice.get_data_requests_by_status(DataRequestStatus::Tallying, 0, 10);
     assert!(!tallying.is_paused);
     assert_eq!(1, tallying.data_requests.len());
     assert!(tallying.data_requests.iter().any(|r| r.id == dr_id));
+}
+
+#[test]
+#[should_panic(expected = "NotCommitted")]
+fn cannot_front_run_commit_reveal() {
+    let test_info = TestInfo::init();
+    let alice = test_info.new_executor("alice", 22, 1);
+    let fred = test_info.new_executor("fred", 22, 1);
+
+    // post a data request
+    let dr = test_helpers::calculate_dr_id_and_args(1, 1);
+    let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
+
+    // alice submits a commitment but fred front-runs it
+    let alice_reveal = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![],
+    };
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    fred.commit_result(&dr_id, &alice_reveal_message).unwrap();
+
+    // fred tries to front-run by copying alice's reveal message
+    // this should fail since the reveal message is for alice's commitment
+    fred.reveal_result(alice_reveal_message).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "RevealMismatch")]
+fn cannot_front_run_reveal() {
+    let test_info = TestInfo::init();
+    let alice = test_info.new_executor("alice", 22, 1);
+    let fred = test_info.new_executor("fred", 22, 1);
+
+    // post a data request
+    let dr = test_helpers::calculate_dr_id_and_args(1, 1);
+    let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
+
+    // alice submits a commitment but fred front-runs it
+    let alice_reveal = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![],
+    };
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal.clone());
+    fred.commit_result(&dr_id, &alice_reveal_message).unwrap();
+
+    // fred tries to copy the reveal body from alice and create their own reveal message
+    // this should fail since fred's commitment was for alice's reveal message
+    let fred_reveal_message = fred.create_reveal_message(alice_reveal);
+    fred.reveal_result(fred_reveal_message).unwrap();
 }

--- a/contract/src/msgs/data_requests/tests/timeout_actions.rs
+++ b/contract/src/msgs/data_requests/tests/timeout_actions.rs
@@ -1,6 +1,6 @@
 use seda_common::{
     msgs::data_requests::{DataRequestStatus, RevealBody, TimeoutConfig},
-    types::{HashSelf, TryHashSelf},
+    types::HashSelf,
 };
 
 use crate::{msgs::data_requests::test_helpers, TestInfo};
@@ -52,14 +52,15 @@ fn timed_out_requests_move_to_tally() {
 
     // alice commits a data result
     let alice_reveal = RevealBody {
-        id:                dr_id2.clone(),
-        salt:              alice.salt(),
+        dr_id:             dr_id2.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
-    alice.commit_result(&dr_id2, alice_reveal.try_hash().unwrap()).unwrap();
+    let alice_reveal_message = alice.create_reveal_message(alice_reveal);
+    alice.commit_result(&dr_id2, &alice_reveal_message).unwrap();
 
     // set the block height to be later than the timeout so it times out during the reveal phase
     test_info.set_block_height(21);

--- a/contract/src/msgs/staking/tests.rs
+++ b/contract/src/msgs/staking/tests.rs
@@ -353,17 +353,18 @@ fn executor_not_eligible_if_dr_resolved() {
         .unwrap();
 
     let reveal = RevealBody {
-        id:                dr_id.clone(),
-        salt:              anyone.salt(),
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
         reveal:            "10".hash().into(),
         gas_used:          0,
         exit_code:         0,
         proxy_public_keys: vec![],
     };
+    let anyone_reveal_message = anyone.create_reveal_message(reveal);
     // commit
-    anyone.commit_result(&dr_id, reveal.try_hash().unwrap()).unwrap();
+    anyone.commit_result(&dr_id, &anyone_reveal_message).unwrap();
     // reveal
-    anyone.reveal_result(&dr_id, reveal.clone()).unwrap();
+    anyone.reveal_result(anyone_reveal_message).unwrap();
 
     // Owner removes the data request
     test_info

--- a/contract/src/test_utils.rs
+++ b/contract/src/test_utils.rs
@@ -12,10 +12,9 @@ use k256::{
 };
 use seda_common::{msgs::*, types::ToHexStr};
 use serde::{de::DeserializeOwned, Serialize};
-use sha3::{Digest, Keccak256};
 use vrf_rs::Secp256k1Sha256;
 
-use crate::{common_types::Hash, contract::*, error::ContractError, types::PublicKey};
+use crate::{contract::*, error::ContractError, types::PublicKey};
 
 pub fn new_public_key() -> (SigningKey, PublicKey) {
     let signing_key = SigningKey::random(&mut OsRng);
@@ -323,13 +322,6 @@ impl TestAccount {
 
     pub fn prove_hex(&self, hash: &[u8]) -> String {
         self.prove(hash).to_hex()
-    }
-
-    pub fn salt(&self) -> String {
-        let mut hasher = Keccak256::new();
-        hasher.update(self.name);
-        let hash: Hash = hasher.finalize().into();
-        hash.to_hex()
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -138,12 +138,11 @@ fn tally_test_fixture(n: usize) -> Vec<DataRequest> {
 
             let dr_id: [u8; 32] = rand::random();
             let hex_dr_id = dr_id.to_hex();
-            let salt: [u8; 32] = rand::random();
             let reveals = (0..replication_factor)
                 .map(|_| {
                     let reveal = RevealBody {
-                        id:                hex_dr_id.clone(),
-                        salt:              salt.to_hex(),
+                        dr_id:             hex_dr_id.clone(),
+                        dr_block_height:   1,
                         exit_code:         0,
                         gas_used:          10,
                         reveal:            rand::rng().random_range(1..=100u8).to_be_bytes().into(),


### PR DESCRIPTION
## Motivation

Bring implementation up to date with the spec found here: https://www.notion.so/sedaprotocol/20240227-Implementation-of-Commitment-Scheme-1a7a68d575ca80c3966dc03c3488ce61

This prevents front-running and freeloading as the commitment now includes private material from the executor identity that created the reveal message.

## Explanation of Changes

- Commitment is now the hash of the of the reveal message rather than just the reveal body.
- Reveal Body removes the salt, and adds the dr height.

## Testing

Tests updated and new ones added.

## Related PRs and Issues

N/A
