### PR TITLE
Feat: cost sorted index

### DIFF
--- a/contract/src/msgs/data_requests/execute/commit_result.rs
+++ b/contract/src/msgs/data_requests/execute/commit_result.rs
@@ -25,7 +25,7 @@ impl ExecuteHandler for execute::commit_result::Execute {
                 ("version", CONTRACT_VERSION.to_string()),
             ]),
         );
-        state::commit(deps.storage, env.block.height, dr_id, dr)?;
+        state::commit(deps.storage, env.block.height, &dr_id, dr)?;
         Ok(resp)
     }
 }

--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -44,11 +44,12 @@ impl ExecuteHandler for execute::post_request::Execute {
         // Take the funds from the user
         let token = TOKEN.load(deps.storage)?;
         let funds = cw_utils::must_pay(&info, &token)?;
-        let required = (Uint128::from(self.posted_dr.exec_gas_limit) + Uint128::from(self.posted_dr.tally_gas_limit))
-            .checked_mul(self.posted_dr.gas_price)?;
-        if funds < required {
+        let required_cost = (Uint128::from(self.posted_dr.exec_gas_limit)
+            + Uint128::from(self.posted_dr.tally_gas_limit))
+        .checked_mul(self.posted_dr.gas_price)?;
+        if funds < required_cost {
             return Err(ContractError::InsufficientFunds(
-                required,
+                required_cost,
                 get_attached_funds(&info.funds, &token)?,
             ));
         };
@@ -111,7 +112,7 @@ impl ExecuteHandler for execute::post_request::Execute {
 
             height: env.block.height,
         };
-        state::post_request(deps.storage, env.block.height, dr_id, dr)?;
+        state::post_request(deps.storage, env.block.height, dr_id, required_cost, dr)?;
 
         Ok(res)
     }

--- a/contract/src/msgs/data_requests/execute/reveal_result.rs
+++ b/contract/src/msgs/data_requests/execute/reveal_result.rs
@@ -67,7 +67,7 @@ impl ExecuteHandler for execute::reveal_result::Execute {
 
         // add the reveal to the data request state
         dr.reveals.insert(self.public_key.clone(), self.reveal_body);
-        state::reveal(deps.storage, dr_id, dr, env.block.height)?;
+        state::reveal(deps.storage, &dr_id, dr, env.block.height)?;
 
         Ok(response)
     }

--- a/contract/src/msgs/data_requests/state/data_requests_map.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::msgs::data_structures::EnumerableSet;
 
 pub struct DataRequestsMap<'a> {
     pub reqs:       Map<&'a Hash, DataRequest>,
@@ -198,7 +199,7 @@ impl DataRequestsMap<'_> {
             DataRequestStatus::Revealing => &self.revealing,
             DataRequestStatus::Tallying => &self.tallying,
         }
-        .index_to_key
+        .index_to_value
         .range(store, start, end, Order::Ascending)
         .flat_map(|result| result.map(|(_, key)| self.reqs.load(store, &key)))
         .collect::<StdResult<Vec<_>>>()?;

--- a/contract/src/msgs/data_requests/state/data_requests_map.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map.rs
@@ -68,16 +68,16 @@ impl DataRequestsMap<'_> {
         req: DataRequest,
         status: &DataRequestStatus,
     ) -> StdResult<()> {
-        if self.has(store, &entry.key) {
+        if self.has(store, &entry.hash) {
             return Err(StdError::generic_err("Key already exists"));
         }
 
-        self.reqs.save(store, &entry.key, &req)?;
+        self.reqs.save(store, &entry.hash, &req)?;
         let timeout_config = TIMEOUT_CONFIG.load(store)?;
         self.timeouts.insert(
             store,
             current_height + timeout_config.commit_timeout_in_blocks,
-            &entry.key,
+            &entry.hash,
         )?;
         self.add_to_status(store, entry, status)?;
 
@@ -221,7 +221,7 @@ impl DataRequestsMap<'_> {
         }
         .index_to_value
         .range(store, start, end, Order::Ascending)
-        .flat_map(|result| result.map(|(_, entry)| self.reqs.load(store, &entry.key)))
+        .flat_map(|result| result.map(|(_, entry)| self.reqs.load(store, &entry.hash)))
         .collect::<StdResult<Vec<_>>>()?;
 
         Ok(requests)

--- a/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
@@ -54,7 +54,7 @@ impl TestInfo<'_> {
         };
         assert_eq!(
             key,
-            status_map.index_to_key.may_load(&self.store, status_index).unwrap()
+            status_map.index_to_value.may_load(&self.store, status_index).unwrap()
         );
     }
 

--- a/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
@@ -2,7 +2,10 @@ use test_helpers::{calculate_dr_id_and_args, construct_dr};
 use testing::MockStorage;
 
 use super::*;
-use crate::consts::{INITIAL_COMMIT_TIMEOUT_IN_BLOCKS, INITIAL_REVEAL_TIMEOUT_IN_BLOCKS};
+use crate::{
+    consts::{INITIAL_COMMIT_TIMEOUT_IN_BLOCKS, INITIAL_REVEAL_TIMEOUT_IN_BLOCKS},
+    msgs::data_requests::consts::min_post_dr_cost,
+};
 
 struct TestInfo<'a> {
     pub store: MockStorage,
@@ -36,7 +39,7 @@ impl TestInfo<'_> {
     }
 
     #[track_caller]
-    fn assert_status_key_to_index(&self, status: &DataRequestStatus, key: Hash, index: Option<u32>) {
+    fn assert_status_key_to_index(&self, status: &DataRequestStatus, key: &Hash, index: Option<u32>) {
         let status_map = match status {
             DataRequestStatus::Committing => &self.map.committing,
             DataRequestStatus::Revealing => &self.map.revealing,
@@ -46,25 +49,25 @@ impl TestInfo<'_> {
     }
 
     #[track_caller]
-    fn assert_status_index_to_key(&self, status: &DataRequestStatus, status_index: u32, key: Option<Hash>) {
+    fn assert_status_index_to_key(&self, status: &DataRequestStatus, status_index: u32, entry: Option<Entry<'_>>) {
         let status_map = match status {
             DataRequestStatus::Committing => &self.map.committing,
             DataRequestStatus::Revealing => &self.map.revealing,
             DataRequestStatus::Tallying => &self.map.tallying,
         };
         assert_eq!(
-            key,
+            entry,
             status_map.index_to_value.may_load(&self.store, status_index).unwrap()
         );
     }
 
     #[track_caller]
-    fn insert(&mut self, current_height: u64, key: Hash, value: DataRequest) {
+    fn insert(&mut self, current_height: u64, entry: Entry<'_>, value: DataRequest) {
         self.map
             .insert(
                 &mut self.store,
                 current_height,
-                key,
+                entry,
                 value,
                 &DataRequestStatus::Committing,
             )
@@ -72,12 +75,12 @@ impl TestInfo<'_> {
     }
 
     #[track_caller]
-    fn insert_removable(&mut self, current_height: u64, key: Hash, value: DataRequest) {
+    fn insert_removable(&mut self, current_height: u64, entry: Entry<'_>, value: DataRequest) {
         self.map
             .insert(
                 &mut self.store,
                 current_height,
-                key,
+                entry,
                 value,
                 &DataRequestStatus::Tallying,
             )
@@ -85,14 +88,14 @@ impl TestInfo<'_> {
     }
 
     #[track_caller]
-    fn update(&mut self, key: Hash, dr: DataRequest, status: Option<DataRequestStatus>, current_height: u64) {
+    fn update(&mut self, key: &Hash, dr: DataRequest, status: Option<DataRequestStatus>, current_height: u64) {
         self.map
             .update(&mut self.store, key, dr, status, current_height, false)
             .unwrap();
     }
 
     #[track_caller]
-    fn remove(&mut self, key: Hash) {
+    fn remove(&mut self, key: &Hash) {
         self.map.remove(&mut self.store, key).unwrap();
     }
 
@@ -114,12 +117,14 @@ impl TestInfo<'_> {
     }
 }
 
-fn create_test_dr(nonce: u128) -> (Hash, DataRequest) {
+fn create_test_dr<'a>(nonce: u128, cost: Option<u128>) -> (Entry<'a>, DataRequest) {
     let args = calculate_dr_id_and_args(nonce, 2);
     let id = nonce.to_string().hash();
     let dr = construct_dr(args, vec![], nonce as u64);
+    let cost = Uint128::new(cost.unwrap_or(min_post_dr_cost()));
+    let entry = Entry::new(cost, id);
 
-    (id, dr)
+    (entry, dr)
 }
 
 #[test]
@@ -135,20 +140,20 @@ fn enum_map_insert() {
     let mut test_info = TestInfo::init();
     const TEST_STATUS: &DataRequestStatus = &DataRequestStatus::Committing;
 
-    let (key, val) = create_test_dr(1);
-    test_info.insert(1, key, val);
+    let (entry, val) = create_test_dr(1, None);
+    test_info.insert(1, entry.clone(), val);
     test_info.assert_status_len(1, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, key, Some(0));
-    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(key));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry.key, Some(0));
+    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry));
 }
 
 #[test]
 fn enum_map_get() {
     let mut test_info = TestInfo::init();
 
-    let (key, req) = create_test_dr(1);
-    test_info.insert(1, key, req.clone());
-    test_info.assert_request(&key, Some(req))
+    let (entry, req) = create_test_dr(1, None);
+    test_info.insert(1, entry.clone(), req.clone());
+    test_info.assert_request(&entry.key, Some(req))
 }
 
 #[test]
@@ -158,7 +163,7 @@ fn enum_map_get_non_existing() {
 
     test_info.assert_request(&"1".hash(), None);
     test_info.assert_status_len(0, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, "1".hash(), None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &"1".hash(), None);
     test_info.assert_status_index_to_key(TEST_STATUS, 0, None);
 }
 
@@ -166,9 +171,9 @@ fn enum_map_get_non_existing() {
 #[should_panic(expected = "Key already exists")]
 fn enum_map_insert_duplicate() {
     let mut test_info = TestInfo::init();
-    let (key, req) = create_test_dr(1);
-    test_info.insert(1, key, req.clone());
-    test_info.insert(1, key, req);
+    let (entry, req) = create_test_dr(1, None);
+    test_info.insert(1, entry.clone(), req.clone());
+    test_info.insert(1, entry, req);
 }
 
 #[test]
@@ -176,28 +181,28 @@ fn enum_map_update() {
     let mut test_info = TestInfo::init();
     const TEST_STATUS: &DataRequestStatus = &DataRequestStatus::Committing;
 
-    let (key1, dr1) = create_test_dr(1);
-    let (_, dr2) = create_test_dr(2);
+    let (entry1, dr1) = create_test_dr(1, None);
+    let (_, dr2) = create_test_dr(2, None);
     let current_height = 1;
 
-    test_info.insert(current_height, key1, dr1.clone());
+    test_info.insert(current_height, entry1.clone(), dr1.clone());
     test_info.assert_status_len(1, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, key1, Some(0));
-    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(key1));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, Some(0));
+    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry1.clone()));
 
-    test_info.update(key1, dr2.clone(), None, current_height);
+    test_info.update(&entry1.key, dr2.clone(), None, current_height);
     test_info.assert_status_len(1, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, key1, Some(0));
-    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(key1));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, Some(0));
+    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry1));
 }
 
 #[test]
 #[should_panic(expected = "Key does not exist")]
 fn enum_map_update_non_existing() {
     let mut test_info = TestInfo::init();
-    let (key, req) = create_test_dr(1);
+    let (entry1, req) = create_test_dr(1, None);
     let current_height = 1;
-    test_info.update(key, req, None, current_height);
+    test_info.update(&entry1.key, req, None, current_height);
 }
 
 #[test]
@@ -205,26 +210,26 @@ fn enum_map_remove_first() {
     let mut test_info = TestInfo::init();
     const TEST_STATUS: &DataRequestStatus = &DataRequestStatus::Tallying;
 
-    let (key1, req1) = create_test_dr(1);
-    let (key2, req2) = create_test_dr(2);
-    let (key3, req3) = create_test_dr(3);
+    let (entry1, req1) = create_test_dr(1, Some(3));
+    let (entry2, req2) = create_test_dr(2, Some(2));
+    let (entry3, req3) = create_test_dr(3, Some(1));
 
-    test_info.insert_removable(1, key1, req1.clone()); // 0
-    test_info.insert_removable(1, key2, req2.clone()); // 1
-    test_info.insert_removable(1, key3, req3.clone()); // 2
+    test_info.insert_removable(1, entry1.clone(), req1.clone()); // 0
+    test_info.insert_removable(1, entry2.clone(), req2.clone()); // 1
+    test_info.insert_removable(1, entry3.clone(), req3.clone()); // 2
 
-    test_info.remove(key1);
+    test_info.remove(&entry1.key);
     test_info.assert_status_len(2, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, key3, Some(0));
-    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(key3));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.key, Some(1));
+    test_info.assert_status_index_to_key(TEST_STATUS, 1, Some(entry3.clone()));
 
     // test that we can still get the other keys
-    test_info.assert_request(&key2, Some(req2.clone()));
-    test_info.assert_request(&key3, Some(req3.clone()));
+    test_info.assert_request(&entry2.key, Some(req2.clone()));
+    test_info.assert_request(&entry3.key, Some(req3.clone()));
 
     // test that the req is removed
-    test_info.assert_request(&key1, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, key1, None);
+    test_info.assert_request(&entry1.key, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, None);
 }
 
 #[test]
@@ -232,27 +237,27 @@ fn enum_map_remove_last() {
     let mut test_info = TestInfo::init();
     const TEST_STATUS: &DataRequestStatus = &DataRequestStatus::Tallying;
 
-    let (key1, req1) = create_test_dr(1);
-    let (key2, req2) = create_test_dr(2);
-    let (key3, req3) = create_test_dr(3);
+    let (entry1, req1) = create_test_dr(1, None);
+    let (entry2, req2) = create_test_dr(2, None);
+    let (entry3, req3) = create_test_dr(3, None);
 
-    test_info.insert_removable(1, key1, req1.clone()); // 0
-    test_info.insert_removable(1, key2, req2.clone()); // 1
-    test_info.insert_removable(1, key3, req3.clone()); // 2
+    test_info.insert_removable(1, entry1.clone(), req1.clone()); // 0
+    test_info.insert_removable(1, entry2.clone(), req2.clone()); // 1
+    test_info.insert_removable(1, entry3.clone(), req3.clone()); // 2
     test_info.assert_status_len(3, TEST_STATUS);
 
-    test_info.remove(key3);
+    test_info.remove(&entry3.key);
     test_info.assert_status_len(2, TEST_STATUS);
     test_info.assert_status_index_to_key(TEST_STATUS, 2, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, key3, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.key, None);
 
     // check that the other keys are still there
-    assert_eq!(test_info.get(&key1), Some(req1.clone()));
-    assert_eq!(test_info.get(&key2), Some(req2.clone()));
+    assert_eq!(test_info.get(&entry1.key), Some(req1.clone()));
+    assert_eq!(test_info.get(&entry2.key), Some(req2.clone()));
 
     // test that the status indexes are still there
-    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(key1));
-    test_info.assert_status_index_to_key(TEST_STATUS, 1, Some(key2));
+    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry1));
+    test_info.assert_status_index_to_key(TEST_STATUS, 1, Some(entry2));
 }
 
 #[test]
@@ -260,38 +265,43 @@ fn enum_map_remove() {
     let mut test_info = TestInfo::init();
     const TEST_STATUS: &DataRequestStatus = &DataRequestStatus::Tallying;
 
-    let (key1, req1) = create_test_dr(1);
-    let (key2, req2) = create_test_dr(2);
-    let (key3, req3) = create_test_dr(3);
-    let (key4, req4) = create_test_dr(4);
+    let (entry1, req1) = create_test_dr(1, Some(1));
+    let (entry2, req2) = create_test_dr(2, Some(4));
+    let (entry3, req3) = create_test_dr(3, Some(3));
+    let (entry4, req4) = create_test_dr(4, Some(2));
 
-    test_info.insert_removable(1, key1, req1.clone()); // 0
-    test_info.insert_removable(1, key2, req2.clone()); // 1
-    test_info.insert_removable(1, key3, req3.clone()); // 2
-    test_info.insert_removable(1, key4, req4.clone()); // 3
+    test_info.insert_removable(1, entry1.clone(), req1.clone());
+    test_info.insert_removable(1, entry2.clone(), req2.clone());
+    test_info.insert_removable(1, entry3.clone(), req3.clone());
+    test_info.insert_removable(1, entry4.clone(), req4.clone());
+    // indexes should be ordered by cost:
+    // entry1: 3
+    // entry2: 0
+    // entry3: 1
+    // entry4: 2
     test_info.assert_status_len(4, &DataRequestStatus::Tallying);
 
-    test_info.remove(key2);
+    test_info.remove(&entry2.key);
 
     // test that the key is removed
     test_info.assert_status_len(3, &DataRequestStatus::Tallying);
-    test_info.assert_request(&key2, None);
+    test_info.assert_request(&entry2.key, None);
 
     // check that the other keys are still there
-    test_info.assert_request(&key1, Some(req1));
-    test_info.assert_request(&key3, Some(req3));
-    test_info.assert_request(&key4, Some(req4));
+    test_info.assert_request(&entry1.key, Some(req1));
+    test_info.assert_request(&entry3.key, Some(req3));
+    test_info.assert_request(&entry4.key, Some(req4));
 
     // check that the status is updated
-    test_info.assert_status_key_to_index(TEST_STATUS, key1, Some(0));
-    test_info.assert_status_key_to_index(TEST_STATUS, key2, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, key3, Some(2));
-    test_info.assert_status_key_to_index(TEST_STATUS, key4, Some(1));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, Some(2));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry2.key, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.key, Some(0));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry4.key, Some(1));
 
     // check the status indexes
-    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(key1));
-    test_info.assert_status_index_to_key(TEST_STATUS, 1, Some(key4));
-    test_info.assert_status_index_to_key(TEST_STATUS, 2, Some(key3));
+    test_info.assert_status_index_to_key(TEST_STATUS, 2, Some(entry1));
+    test_info.assert_status_index_to_key(TEST_STATUS, 1, Some(entry4));
+    test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry3));
     test_info.assert_status_index_to_key(TEST_STATUS, 3, None);
 }
 
@@ -299,7 +309,7 @@ fn enum_map_remove() {
 #[should_panic(expected = "Key does not exist")]
 fn enum_map_remove_non_existing() {
     let mut test_info = TestInfo::init();
-    test_info.remove(2.to_string().hash());
+    test_info.remove(&2.to_string().hash());
 }
 
 #[test]
@@ -307,12 +317,17 @@ fn get_requests_by_status() {
     let mut test_info = TestInfo::init();
     let current_height = 1;
 
-    let (key1, req1) = create_test_dr(1);
-    test_info.insert(current_height, key1, req1.clone());
+    let (entry1, req1) = create_test_dr(1, None);
+    test_info.insert(current_height, entry1.clone(), req1.clone());
 
-    let (key2, req2) = create_test_dr(2);
-    test_info.insert(current_height, key2, req2.clone());
-    test_info.update(key2, req2.clone(), Some(DataRequestStatus::Revealing), current_height);
+    let (entry2, req2) = create_test_dr(2, None);
+    test_info.insert(current_height, entry2.clone(), req2.clone());
+    test_info.update(
+        &entry2.key,
+        req2.clone(),
+        Some(DataRequestStatus::Revealing),
+        current_height,
+    );
 
     let committing = test_info.get_requests_by_status(DataRequestStatus::Committing, 0, 10);
     assert_eq!(committing.len(), 1);
@@ -331,8 +346,8 @@ fn get_requests_by_status_pagination() {
 
     // indexes 0 - 9
     for i in 0..10 {
-        let (key, req) = create_test_dr(i);
-        test_info.insert(1, key, req.clone());
+        let (entry, req) = create_test_dr(i, None);
+        test_info.insert(1, entry, req.clone());
         reqs.push(req);
     }
 
@@ -356,7 +371,7 @@ fn get_requests_by_status_pagination() {
 #[should_panic(expected = "Key does not exist")]
 fn remove_from_empty() {
     let mut test_info = TestInfo::init();
-    test_info.remove(1.to_string().hash());
+    test_info.remove(&1.to_string().hash());
 }
 
 #[test]
@@ -364,11 +379,11 @@ fn remove_only_item() {
     let mut test_info = TestInfo::init();
     const TEST_STATUS: &DataRequestStatus = &DataRequestStatus::Tallying;
 
-    let (key, req) = create_test_dr(1);
-    test_info.insert_removable(1, key, req.clone());
-    test_info.remove(key);
+    let (entry, req) = create_test_dr(1, None);
+    test_info.insert_removable(1, entry.clone(), req.clone());
+    test_info.remove(&entry.key);
 
     test_info.assert_status_len(0, &DataRequestStatus::Tallying);
     test_info.assert_status_index_to_key(TEST_STATUS, 0, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, key, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry.key, None);
 }

--- a/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
@@ -143,7 +143,7 @@ fn enum_map_insert() {
     let (entry, val) = create_test_dr(1, None);
     test_info.insert(1, entry.clone(), val);
     test_info.assert_status_len(1, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry.key, Some(0));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry.hash, Some(0));
     test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry));
 }
 
@@ -153,7 +153,7 @@ fn enum_map_get() {
 
     let (entry, req) = create_test_dr(1, None);
     test_info.insert(1, entry.clone(), req.clone());
-    test_info.assert_request(&entry.key, Some(req))
+    test_info.assert_request(&entry.hash, Some(req))
 }
 
 #[test]
@@ -187,12 +187,12 @@ fn enum_map_update() {
 
     test_info.insert(current_height, entry1.clone(), dr1.clone());
     test_info.assert_status_len(1, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, Some(0));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.hash, Some(0));
     test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry1.clone()));
 
-    test_info.update(&entry1.key, dr2.clone(), None, current_height);
+    test_info.update(&entry1.hash, dr2.clone(), None, current_height);
     test_info.assert_status_len(1, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, Some(0));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.hash, Some(0));
     test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry1));
 }
 
@@ -202,7 +202,7 @@ fn enum_map_update_non_existing() {
     let mut test_info = TestInfo::init();
     let (entry1, req) = create_test_dr(1, None);
     let current_height = 1;
-    test_info.update(&entry1.key, req, None, current_height);
+    test_info.update(&entry1.hash, req, None, current_height);
 }
 
 #[test]
@@ -218,18 +218,18 @@ fn enum_map_remove_first() {
     test_info.insert_removable(1, entry2.clone(), req2.clone()); // 1
     test_info.insert_removable(1, entry3.clone(), req3.clone()); // 2
 
-    test_info.remove(&entry1.key);
+    test_info.remove(&entry1.hash);
     test_info.assert_status_len(2, TEST_STATUS);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.key, Some(1));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.hash, Some(1));
     test_info.assert_status_index_to_key(TEST_STATUS, 1, Some(entry3.clone()));
 
     // test that we can still get the other keys
-    test_info.assert_request(&entry2.key, Some(req2.clone()));
-    test_info.assert_request(&entry3.key, Some(req3.clone()));
+    test_info.assert_request(&entry2.hash, Some(req2.clone()));
+    test_info.assert_request(&entry3.hash, Some(req3.clone()));
 
     // test that the req is removed
-    test_info.assert_request(&entry1.key, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, None);
+    test_info.assert_request(&entry1.hash, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.hash, None);
 }
 
 #[test]
@@ -246,14 +246,14 @@ fn enum_map_remove_last() {
     test_info.insert_removable(1, entry3.clone(), req3.clone()); // 2
     test_info.assert_status_len(3, TEST_STATUS);
 
-    test_info.remove(&entry3.key);
+    test_info.remove(&entry3.hash);
     test_info.assert_status_len(2, TEST_STATUS);
     test_info.assert_status_index_to_key(TEST_STATUS, 2, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.key, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.hash, None);
 
     // check that the other keys are still there
-    assert_eq!(test_info.get(&entry1.key), Some(req1.clone()));
-    assert_eq!(test_info.get(&entry2.key), Some(req2.clone()));
+    assert_eq!(test_info.get(&entry1.hash), Some(req1.clone()));
+    assert_eq!(test_info.get(&entry2.hash), Some(req2.clone()));
 
     // test that the status indexes are still there
     test_info.assert_status_index_to_key(TEST_STATUS, 0, Some(entry1));
@@ -281,22 +281,22 @@ fn enum_map_remove() {
     // entry4: 2
     test_info.assert_status_len(4, &DataRequestStatus::Tallying);
 
-    test_info.remove(&entry2.key);
+    test_info.remove(&entry2.hash);
 
     // test that the key is removed
     test_info.assert_status_len(3, &DataRequestStatus::Tallying);
-    test_info.assert_request(&entry2.key, None);
+    test_info.assert_request(&entry2.hash, None);
 
     // check that the other keys are still there
-    test_info.assert_request(&entry1.key, Some(req1));
-    test_info.assert_request(&entry3.key, Some(req3));
-    test_info.assert_request(&entry4.key, Some(req4));
+    test_info.assert_request(&entry1.hash, Some(req1));
+    test_info.assert_request(&entry3.hash, Some(req3));
+    test_info.assert_request(&entry4.hash, Some(req4));
 
     // check that the status is updated
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.key, Some(2));
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry2.key, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.key, Some(0));
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry4.key, Some(1));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry1.hash, Some(2));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry2.hash, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry3.hash, Some(0));
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry4.hash, Some(1));
 
     // check the status indexes
     test_info.assert_status_index_to_key(TEST_STATUS, 2, Some(entry1));
@@ -323,7 +323,7 @@ fn get_requests_by_status() {
     let (entry2, req2) = create_test_dr(2, None);
     test_info.insert(current_height, entry2.clone(), req2.clone());
     test_info.update(
-        &entry2.key,
+        &entry2.hash,
         req2.clone(),
         Some(DataRequestStatus::Revealing),
         current_height,
@@ -381,9 +381,9 @@ fn remove_only_item() {
 
     let (entry, req) = create_test_dr(1, None);
     test_info.insert_removable(1, entry.clone(), req.clone());
-    test_info.remove(&entry.key);
+    test_info.remove(&entry.hash);
 
     test_info.assert_status_len(0, &DataRequestStatus::Tallying);
     test_info.assert_status_index_to_key(TEST_STATUS, 0, None);
-    test_info.assert_status_key_to_index(TEST_STATUS, &entry.key, None);
+    test_info.assert_status_key_to_index(TEST_STATUS, &entry.hash, None);
 }

--- a/contract/src/msgs/data_requests/sudo/remove_requests.rs
+++ b/contract/src/msgs/data_requests/sudo/remove_requests.rs
@@ -196,7 +196,7 @@ fn remove_request_and_process_distributions(
         event = event.add_attribute("refund", dr_escrow.amount.to_string());
     }
 
-    if state::remove_request(deps.storage, dr_id).is_err() {
+    if state::remove_request(deps.storage, &dr_id).is_err() {
         event = event.add_attribute("failed_to_remove_dr", dr_id_str);
     };
     DR_ESCROW.remove(deps.storage, &dr_id);

--- a/contract/src/msgs/data_structures/cost_sorted_index.rs
+++ b/contract/src/msgs/data_structures/cost_sorted_index.rs
@@ -7,9 +7,19 @@ use serde::{Deserialize, Serialize};
 use super::IndexKeyedSet;
 
 #[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 pub struct Entry<'a> {
     pub cost: Uint128,
     pub key:  Cow<'a, Hash>,
+}
+
+impl Entry<'_> {
+    pub fn new(cost: Uint128, key: Hash) -> Self {
+        Self {
+            cost,
+            key: Cow::Owned(key),
+        }
+    }
 }
 
 pub struct CostSorted;

--- a/contract/src/msgs/data_structures/cost_sorted_index.rs
+++ b/contract/src/msgs/data_structures/cost_sorted_index.rs
@@ -6,26 +6,37 @@ use serde::{Deserialize, Serialize};
 
 use super::IndexKeyedSet;
 
+/// A struct that represents an entry in the cost-sorted index.
+/// It contains a cost and a dr id.
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 pub struct Entry<'a> {
     pub cost: Uint128,
-    pub key:  Cow<'a, Hash>,
+    /// The hash of the data request.
+    /// A cow is used to avoid cloning the key when it is already owned.
+    pub hash: Cow<'a, Hash>,
 }
 
 impl Entry<'_> {
     pub fn new(cost: Uint128, key: Hash) -> Self {
         Self {
             cost,
-            key: Cow::Owned(key),
+            hash: Cow::Owned(key),
         }
     }
 }
 
+/// A zero-sized type used to mark the `IndexKeyedSet` as a cost-sorted index.
 pub struct CostSorted;
+/// A type alias for an `IndexKeyedSet` that is a cost-sorted index.
 pub type CostSortedIndex<'a> = IndexKeyedSet<Entry<'a>, &'a Hash, CostSorted>;
 
+// TODO: could improve this with a binary search...
 impl<'a> IndexKeyedSet<Entry<'a>, &'a Hash, CostSorted> {
+    /// Adds an entry to the cost-sorted index in O(n) time.
+    /// The entry is inserted in descending order of cost.
+    /// If two entries have the same cost, the new entry is appended making it a
+    /// LILO (Last In Last Out) data structure.
     pub fn add(&self, store: &mut dyn Storage, entry: Entry<'_>) -> StdResult<()> {
         let len = self.len(store)?;
         let mut pos = len;
@@ -42,14 +53,15 @@ impl<'a> IndexKeyedSet<Entry<'a>, &'a Hash, CostSorted> {
         for i in (pos..len).rev() {
             let old_entry = self.index_to_value.load(store, i)?;
             self.index_to_value.save(store, i + 1, &old_entry)?;
-            self.key_to_index.save(store, &old_entry.key, &(i + 1))?;
+            self.key_to_index.save(store, &old_entry.hash, &(i + 1))?;
         }
         self.index_to_value.save(store, pos, &entry)?;
-        self.key_to_index.save(store, &entry.key, &pos)?;
+        self.key_to_index.save(store, &entry.hash, &pos)?;
         self.len.save(store, &(len + 1))?;
         Ok(())
     }
 
+    /// Removes an entry from the cost-sorted index in O(n) time.
     pub fn remove(&self, store: &mut dyn Storage, key: &Hash) -> StdResult<()> {
         let pos = self.key_to_index.load(store, key)?;
         let len = self.len(store)?;
@@ -59,7 +71,7 @@ impl<'a> IndexKeyedSet<Entry<'a>, &'a Hash, CostSorted> {
         for i in pos + 1..len {
             let entry = self.index_to_value.load(store, i)?;
             self.index_to_value.save(store, i - 1, &entry)?;
-            self.key_to_index.save(store, &entry.key, &(i - 1))?;
+            self.key_to_index.save(store, &entry.hash, &(i - 1))?;
         }
         self.index_to_value.remove(store, len - 1);
         self.len.save(store, &(len - 1))?;

--- a/contract/src/msgs/data_structures/cost_sorted_index.rs
+++ b/contract/src/msgs/data_structures/cost_sorted_index.rs
@@ -1,0 +1,70 @@
+use std::borrow::Cow;
+
+use cosmwasm_std::{StdResult, Storage, Uint128};
+use seda_common::types::Hash;
+use serde::{Deserialize, Serialize};
+
+use super::IndexKeyedSet;
+
+#[derive(Serialize, Deserialize)]
+pub struct Entry<'a> {
+    pub cost: Uint128,
+    pub key:  Cow<'a, Hash>,
+}
+
+pub struct CostSorted;
+pub type CostSortedIndex<'a> = IndexKeyedSet<Entry<'a>, &'a Hash, CostSorted>;
+
+impl<'a> IndexKeyedSet<Entry<'a>, &'a Hash, CostSorted> {
+    pub fn add(&self, store: &mut dyn Storage, entry: Entry<'_>) -> StdResult<()> {
+        let len = self.len(store)?;
+        let mut pos = len;
+        // In descending order, insert before the first entry with a lower cost.
+        // Equal costs will not trigger this condition, so new entries are appended.
+        for i in 0..len {
+            let existing_entry = self.index_to_value.load(store, i)?;
+            if entry.cost > existing_entry.cost {
+                pos = i;
+                break;
+            }
+        }
+        // Shift entries right to make room.
+        for i in (pos..len).rev() {
+            let old_entry = self.index_to_value.load(store, i)?;
+            self.index_to_value.save(store, i + 1, &old_entry)?;
+            self.key_to_index.save(store, &old_entry.key, &(i + 1))?;
+        }
+        self.index_to_value.save(store, pos, &entry)?;
+        self.key_to_index.save(store, &entry.key, &pos)?;
+        self.len.save(store, &(len + 1))?;
+        Ok(())
+    }
+
+    pub fn remove(&self, store: &mut dyn Storage, key: &Hash) -> StdResult<()> {
+        let pos = self.key_to_index.load(store, key)?;
+        let len = self.len(store)?;
+        self.index_to_value.remove(store, pos);
+        self.key_to_index.remove(store, key);
+        // Shift entries left to fill the gap.
+        for i in pos + 1..len {
+            let entry = self.index_to_value.load(store, i)?;
+            self.index_to_value.save(store, i - 1, &entry)?;
+            self.key_to_index.save(store, &entry.key, &(i - 1))?;
+        }
+        self.index_to_value.remove(store, len - 1);
+        self.len.save(store, &(len - 1))?;
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! cost_sorted_index {
+    ($namespace:expr) => {
+        $crate::msgs::data_structures::IndexKeyedSet {
+            len:            Item::new(concat!($namespace, "_len")),
+            index_to_value: Map::new(concat!($namespace, "_index_to_value")),
+            key_to_index:   Map::new(concat!($namespace, "_key_to_index")),
+            kind:           std::marker::PhantomData::<$crate::msgs::data_structures::CostSorted>,
+        }
+    };
+}

--- a/contract/src/msgs/data_structures/cost_sorted_index_tests.rs
+++ b/contract/src/msgs/data_structures/cost_sorted_index_tests.rs
@@ -1,0 +1,222 @@
+use std::borrow::Cow;
+
+use cosmwasm_std::{testing::MockStorage, Uint128};
+use seda_common::types::Hash;
+
+use super::*;
+use crate::cost_sorted_index;
+
+struct TestInfo<'a> {
+    pub store: MockStorage,
+    pub csi:   CostSortedIndex<'a>,
+}
+
+impl TestInfo<'_> {
+    fn init() -> Self {
+        let mut store = MockStorage::new();
+        let csi: CostSortedIndex = cost_sorted_index!("test");
+        csi.initialize(&mut store).unwrap();
+        Self { store, csi }
+    }
+
+    #[track_caller]
+    fn get_index(&self, key: &Hash) -> u32 {
+        self.csi.get_index(&self.store, key).unwrap()
+    }
+
+    #[track_caller]
+    fn len(&self) -> u32 {
+        self.csi.len(&self.store).unwrap()
+    }
+
+    #[track_caller]
+    fn has(&self, key: &Hash) -> bool {
+        self.csi.has(&self.store, key)
+    }
+
+    #[track_caller]
+    fn get_entry(&self, index: u32) -> Entry {
+        self.csi.index_to_value.load(&self.store, index).unwrap()
+    }
+
+    #[track_caller]
+    fn get_index_by_key(&self, key: &Hash) -> u32 {
+        self.csi.key_to_index.load(&self.store, key).unwrap()
+    }
+
+    #[track_caller]
+    fn get_key_by_index(&self, index: u32) -> Hash {
+        self.csi
+            .index_to_value
+            .load(&self.store, index)
+            .unwrap()
+            .key
+            .into_owned()
+    }
+
+    #[track_caller]
+    fn add(&mut self, cost: u128, key: &Hash) {
+        self.csi
+            .add(
+                &mut self.store,
+                Entry {
+                    cost: cost.into(),
+                    key:  Cow::Borrowed(key),
+                },
+            )
+            .unwrap();
+    }
+
+    #[track_caller]
+    fn remove(&mut self, key: &Hash) {
+        self.csi.remove(&mut self.store, key).unwrap();
+    }
+}
+
+#[test]
+fn add() {
+    let mut info = TestInfo::init();
+    let key = [1; 32];
+    let cost = 1000;
+
+    info.add(cost, &key);
+
+    assert_eq!(info.len(), 1);
+    assert_eq!(info.get_index(&key), 0);
+    assert_eq!(info.get_index_by_key(&key), 0);
+    assert_eq!(info.get_key_by_index(0), key);
+    assert_eq!(info.get_entry(0).cost, Uint128::new(cost));
+}
+
+#[test]
+fn add_sorts_by_cost() {
+    let mut info = TestInfo::init();
+    let key1 = [1; 32];
+    let key2 = [2; 32];
+    let key3 = [3; 32];
+    let cost1 = 1000;
+    let cost2 = 2000;
+    let cost3 = 1500;
+
+    info.add(cost1, &key1);
+    info.add(cost2, &key2);
+    info.add(cost3, &key3);
+
+    assert_eq!(info.len(), 3);
+    assert_eq!(info.get_index(&key1), 2);
+    assert_eq!(info.get_index(&key2), 0);
+    assert_eq!(info.get_index(&key3), 1);
+}
+
+#[test]
+fn adding_same_costs_is_last_in_last_out() {
+    let mut info = TestInfo::init();
+    let key1 = [1; 32];
+    let key2 = [2; 32];
+    let key3 = [3; 32];
+    let cost = 1000;
+
+    info.add(cost, &key1);
+    info.add(cost, &key2);
+    info.add(cost, &key3);
+
+    assert_eq!(info.len(), 3);
+    assert_eq!(info.get_index(&key1), 0);
+    assert_eq!(info.get_index(&key2), 1);
+    assert_eq!(info.get_index(&key3), 2);
+}
+
+#[test]
+fn remove() {
+    let mut info = TestInfo::init();
+    let key = [1; 32];
+    let cost = 1000;
+
+    info.add(cost, &key);
+    info.remove(&key);
+
+    assert_eq!(info.len(), 0);
+    assert!(!info.has(&key));
+}
+
+#[test]
+fn remove_middle() {
+    let mut info = TestInfo::init();
+    let key1 = [1; 32];
+    let key2 = [2; 32];
+    let key3 = [3; 32];
+    let cost1 = 1000;
+    let cost2 = 2000;
+    let cost3 = 1500;
+
+    info.add(cost1, &key1);
+    info.add(cost2, &key2);
+    info.add(cost3, &key3);
+
+    // Remove the key at index 1
+    info.remove(&key3);
+    assert_eq!(info.len(), 2);
+    assert_eq!(info.get_index(&key1), 1);
+    assert_eq!(info.get_index(&key2), 0);
+}
+
+#[test]
+fn remove_last() {
+    let mut info = TestInfo::init();
+    let key1 = [1; 32];
+    let key2 = [2; 32];
+    let key3 = [3; 32];
+    let cost1 = 1000;
+    let cost2 = 2000;
+    let cost3 = 1500;
+
+    info.add(cost1, &key1);
+    info.add(cost2, &key2);
+    info.add(cost3, &key3);
+
+    // Remove the key at index 2
+    info.remove(&key1);
+    assert_eq!(info.len(), 2);
+    assert_eq!(info.get_index(&key2), 0);
+    assert_eq!(info.get_index(&key3), 1);
+}
+
+#[test]
+fn remove_first() {
+    let mut info = TestInfo::init();
+    let key1 = [1; 32];
+    let key2 = [2; 32];
+    let key3 = [3; 32];
+    let cost1 = 1000;
+    let cost2 = 2000;
+    let cost3 = 1500;
+
+    info.add(cost1, &key1);
+    info.add(cost2, &key2);
+    info.add(cost3, &key3);
+
+    // Remove the key at index 0
+    info.remove(&key2);
+    assert_eq!(info.len(), 2);
+    assert_eq!(info.get_index(&key1), 1);
+    assert_eq!(info.get_index(&key3), 0);
+}
+
+#[test]
+fn remove_same_cost() {
+    let mut info = TestInfo::init();
+    let key1 = [1; 32];
+    let key2 = [2; 32];
+    let key3 = [3; 32];
+    let cost = 1000;
+
+    info.add(cost, &key1);
+    info.add(cost, &key2);
+    info.add(cost, &key3);
+    // remove index 1 - should be key2
+    info.remove(&key2);
+
+    assert_eq!(info.len(), 2);
+    assert_eq!(info.get_index(&key1), 0);
+    assert_eq!(info.get_index(&key3), 1);
+}

--- a/contract/src/msgs/data_structures/cost_sorted_index_tests.rs
+++ b/contract/src/msgs/data_structures/cost_sorted_index_tests.rs
@@ -208,15 +208,26 @@ fn remove_same_cost() {
     let key1 = [1; 32];
     let key2 = [2; 32];
     let key3 = [3; 32];
+    let key4 = [4; 32];
     let cost = 1000;
 
     info.add(cost, &key1);
     info.add(cost, &key2);
     info.add(cost, &key3);
+    info.add(cost, &key4);
+
+    // check all are there
+    assert_eq!(info.len(), 4);
+    assert_eq!(info.get_index(&key1), 0);
+    assert_eq!(info.get_index(&key2), 1);
+    assert_eq!(info.get_index(&key3), 2);
+    assert_eq!(info.get_index(&key4), 3);
+
     // remove index 1 - should be key2
     info.remove(&key2);
 
-    assert_eq!(info.len(), 2);
+    assert_eq!(info.len(), 3);
     assert_eq!(info.get_index(&key1), 0);
     assert_eq!(info.get_index(&key3), 1);
+    assert_eq!(info.get_index(&key4), 2);
 }

--- a/contract/src/msgs/data_structures/cost_sorted_index_tests.rs
+++ b/contract/src/msgs/data_structures/cost_sorted_index_tests.rs
@@ -50,7 +50,7 @@ impl TestInfo<'_> {
             .index_to_value
             .load(&self.store, index)
             .unwrap()
-            .key
+            .hash
             .into_owned()
     }
 
@@ -61,7 +61,7 @@ impl TestInfo<'_> {
                 &mut self.store,
                 Entry {
                     cost: cost.into(),
-                    key:  Cow::Borrowed(key),
+                    hash: Cow::Borrowed(key),
                 },
             )
             .unwrap();

--- a/contract/src/msgs/data_structures/enumerable_set.rs
+++ b/contract/src/msgs/data_structures/enumerable_set.rs
@@ -3,8 +3,9 @@ use cw_storage_plus::PrimaryKey;
 
 use super::*;
 
+/// A zero-sized type used to mark the `IndexKeyedSet` as an enumerable set.
 pub struct Enumerable;
-
+/// A type alias for an `IndexKeyedSet` that is an enumerable set.
 pub type EnumerableSet<Key> = IndexKeyedSet<Key, Key, Enumerable>;
 
 impl<'a, Key> IndexKeyedSet<Key, Key, Enumerable>
@@ -24,7 +25,7 @@ where
         Ok(())
     }
 
-    /// Removes a key from the set in O(1) time.
+    /// Removes a key from the set in O(1) time, via swapping with the last item.
     pub fn remove(&self, store: &mut dyn Storage, key: Key) -> StdResult<()> {
         let index = self
             .key_to_index

--- a/contract/src/msgs/data_structures/mod.rs
+++ b/contract/src/msgs/data_structures/mod.rs
@@ -38,10 +38,11 @@ where
         self.len.load(store)
     }
 
-    // /// Returns the key at the given index in O(1) time.
-    // fn at(&self, store: &dyn Storage, index: u32) -> StdResult<Option<Hash>> {
-    //     self.index_to_key.may_load(store, index)
-    // }
+    /// Returns the key at the given index in O(1) time.
+    pub fn at(&self, store: &dyn Storage, key: Key) -> StdResult<Value> {
+        let index = self.key_to_index.load(store, key)?;
+        self.index_to_value.load(store, index)
+    }
 
     /// Returns the index of the key in the set in O(1) time.
     pub fn get_index(&self, store: &dyn Storage, key: Key) -> StdResult<u32> {

--- a/contract/src/msgs/data_structures/mod.rs
+++ b/contract/src/msgs/data_structures/mod.rs
@@ -11,13 +11,19 @@ pub use enumerable_set::{Enumerable, EnumerableSet};
 #[cfg(test)]
 mod cost_sorted_index_tests;
 
+/// A base struct for an index keyed set.
+/// This struct is used to create a set where a key fetches the index.
+/// Then the Value is stored at that index.
 pub struct IndexKeyedSet<Value, Key, Kind> {
     pub len:            Item<u32>,
     pub index_to_value: Map<u32, Value>,
     pub key_to_index:   Map<Key, u32>,
+    /// We use this to add compile-time type checking for the variation in methods between
+    /// a zero size type. So it doesn't have any effect at runtime.
     pub kind:           PhantomData<Kind>,
 }
 
+// The common methods for all IndexKeyedSets Variations
 impl<'a, Value, Key, Kind> IndexKeyedSet<Value, Key, Kind>
 where
     Value: serde::de::DeserializeOwned + serde::Serialize,

--- a/contract/src/msgs/data_structures/mod.rs
+++ b/contract/src/msgs/data_structures/mod.rs
@@ -1,0 +1,50 @@
+use std::marker::PhantomData;
+
+use cosmwasm_std::{StdResult, Storage};
+use cw_storage_plus::{Item, Map, PrimaryKey};
+
+mod cost_sorted_index;
+pub use cost_sorted_index::{CostSorted, CostSortedIndex, Entry};
+mod enumerable_set;
+pub use enumerable_set::{Enumerable, EnumerableSet};
+
+#[cfg(test)]
+mod cost_sorted_index_tests;
+
+pub struct IndexKeyedSet<Value, Key, Kind> {
+    pub len:            Item<u32>,
+    pub index_to_value: Map<u32, Value>,
+    pub key_to_index:   Map<Key, u32>,
+    pub kind:           PhantomData<Kind>,
+}
+
+impl<'a, Value, Key, Kind> IndexKeyedSet<Value, Key, Kind>
+where
+    Value: serde::de::DeserializeOwned + serde::Serialize,
+    Key: PrimaryKey<'a> + serde::Serialize,
+{
+    pub fn initialize(&self, store: &mut dyn Storage) -> StdResult<()> {
+        self.len.save(store, &0)?;
+        Ok(())
+    }
+
+    /// Returns true if the key exists in the set in O(1) time.
+    pub fn has(&self, store: &dyn Storage, key: Key) -> bool {
+        self.key_to_index.has(store, key)
+    }
+
+    /// Returns the length of the set in O(1) time.
+    pub fn len(&self, store: &dyn Storage) -> StdResult<u32> {
+        self.len.load(store)
+    }
+
+    // /// Returns the key at the given index in O(1) time.
+    // fn at(&self, store: &dyn Storage, index: u32) -> StdResult<Option<Hash>> {
+    //     self.index_to_key.may_load(store, index)
+    // }
+
+    /// Returns the index of the key in the set in O(1) time.
+    pub fn get_index(&self, store: &dyn Storage, key: Key) -> StdResult<u32> {
+        self.key_to_index.load(store, key)
+    }
+}

--- a/contract/src/msgs/mod.rs
+++ b/contract/src/msgs/mod.rs
@@ -9,10 +9,9 @@ use seda_common::msgs::{
 use crate::{common_types::*, contract::CONTRACT_VERSION, error::ContractError, types::*};
 
 pub mod data_requests;
-mod enumerable_set;
+mod data_structures;
 pub mod owner;
 pub mod staking;
-pub use enumerable_set::EnumerableSet;
 
 pub trait QueryHandler {
     fn query(self, deps: Deps, env: Env) -> Result<Binary, ContractError>;

--- a/contract/src/msgs/staking/state/stakers_map.rs
+++ b/contract/src/msgs/staking/state/stakers_map.rs
@@ -1,6 +1,7 @@
 use owner::state::ALLOWLIST;
 
 use super::*;
+use crate::msgs::data_structures::EnumerableSet;
 
 pub struct StakersMap<'a> {
     pub stakers:     Map<&'a PublicKey, Staker>,


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Such that if a malicious user spams cheap data requests, we prioritize the more expensive ones.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Refactors `EnumerableSet` to a base `IndexKeyedSet` type.
  - This has a generic `Value` stored at index.
  - It also has a generic `Key` type to access it's index.
  - Has a `PhantomMarker` so that you can use a generic zero size type for different add and remove impls.
  - Uncomments the `at` method so it can be used.
- `EnumerableSet` is now built off the `IndexKeyedSet`. Where the `Value` and `Key` are the same type.
- We now have a `CostSortedIndex` that also uses the `IndexKeyedSet`
  - It currently has O(n) insert and remove. This could be improved by a binary search... but that's for another PR IMO.
  - Where the `Value` is a pair of the dr_id and the cost of it.
  - The `Key` is the dr_id.
  - Adds tests for this at the struct level and also the query_drs level.

> [!WARNING]
> Insertion and removal would always be `O(n)` since we have to shift elements, even if we improve finding the correct location.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

All old tests still pass and new tests also pass.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
