### PR TITLE
feat(staking): improve query is eligible

### DIFF
--- a/contract/src/consts.rs
+++ b/contract/src/consts.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::Uint128;
 
-pub const INITIAL_MINIMUM_STAKE: Uint128 = Uint128::new(1);
+pub const INITIAL_MINIMUM_STAKE: Uint128 = Uint128::new(10);
 
 pub const INITIAL_COMMIT_TIMEOUT_IN_BLOCKS: u64 = 10;
-pub const INITIAL_REVEAL_TIMEOUT_IN_BLOCKS: u64 = 10;
+pub const INITIAL_REVEAL_TIMEOUT_IN_BLOCKS: u64 = 5;

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -44,7 +44,7 @@ pub fn instantiate(
 
     let init_staking_config = msg.staking_config.unwrap_or(StakingConfig {
         minimum_stake:     INITIAL_MINIMUM_STAKE,
-        allowlist_enabled: false,
+        allowlist_enabled: true,
     });
 
     if init_staking_config.minimum_stake.is_zero() {

--- a/contract/src/msgs/data_requests/tests/reveal_dr.rs
+++ b/contract/src/msgs/data_requests/tests/reveal_dr.rs
@@ -154,7 +154,7 @@ fn fails_if_not_in_reveal_status() {
 }
 
 #[test]
-#[should_panic(expected = "DataRequestExpired(11, \"reveal\")")]
+#[should_panic(expected = "DataRequestExpired(6, \"reveal\")")]
 fn fails_if_timed_out() {
     let test_info = TestInfo::init();
     let alice = test_info.new_executor("alice", 22, 1);
@@ -176,7 +176,7 @@ fn fails_if_timed_out() {
     alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // set the block height to be later than the timeout
-    test_info.set_block_height(11);
+    test_info.set_block_height(6);
 
     // alice reveals
     alice.reveal_result(alice_reveal_message).unwrap();
@@ -205,7 +205,7 @@ fn fails_on_expired_dr() {
     alice.commit_result(&dr_id, &alice_reveal_message).unwrap();
 
     // set the block height to be later than the timeout
-    test_info.set_block_height(11);
+    test_info.set_block_height(6);
 
     // expire the data request
     test_info.creator().expire_data_requests().unwrap();

--- a/contract/src/msgs/data_requests/tests/timeout_actions.rs
+++ b/contract/src/msgs/data_requests/tests/timeout_actions.rs
@@ -63,7 +63,7 @@ fn timed_out_requests_move_to_tally() {
     alice.commit_result(&dr_id2, &alice_reveal_message).unwrap();
 
     // set the block height to be later than the timeout so it times out during the reveal phase
-    test_info.set_block_height(21);
+    test_info.set_block_height(16);
 
     // process the timed out requests at current height
     test_info.creator().expire_data_requests().unwrap();

--- a/contract/src/msgs/staking/query.rs
+++ b/contract/src/msgs/staking/query.rs
@@ -55,6 +55,6 @@ impl QueryHandler for is_executor_eligible::Query {
             return Ok(to_json_binary(&false)?);
         }
 
-        Ok(to_json_binary(&is_eligible_for_dr(deps, dr_id, executor)?)?)
+        Ok(to_json_binary(&is_eligible_for_dr(deps, env, dr_id, executor)?)?)
     }
 }

--- a/contract/src/msgs/staking/state/is_eligible_for_dr.rs
+++ b/contract/src/msgs/staking/state/is_eligible_for_dr.rs
@@ -1,43 +1,256 @@
-use cosmwasm_std::Uint256;
 use data_requests::state::load_request;
+use sha3::{Digest, Keccak256};
 
 use super::{staking::state::STAKERS, *};
 
-pub fn is_eligible_for_dr(deps: Deps, dr_id: [u8; 32], public_key: PublicKey) -> Result<bool, ContractError> {
+/// Fixed size hash output type
+type Hash = [u8; 32];
+
+/// Compute deterministic hash for staker selection by combining public key and dr_id
+fn compute_selection_hash(public_key: &[u8], dr_id: &[u8; 32]) -> Hash {
+    let mut hasher = Keccak256::new();
+    hasher.update(public_key);
+    hasher.update(dr_id);
+    hasher.finalize().into()
+}
+
+/// Check if a staker is eligible to execute a data request
+///
+/// # Arguments
+/// * `deps` - Dependencies for storage access
+/// * `env` - Environment info, used for block height
+/// * `dr_id` - Unique identifier of the data request
+/// * `public_key` - Public key of the staker to check
+///
+/// # Returns
+/// * `Ok(true)` if staker is eligible
+/// * `Ok(false)` if staker is not eligible
+/// * `Err` if there's an error accessing storage
+pub fn is_eligible_for_dr(deps: Deps, env: Env, dr_id: [u8; 32], public_key: PublicKey) -> Result<bool, ContractError> {
     let data_request = load_request(deps.storage, &dr_id)?;
     let config = STAKING_CONFIG.load(deps.storage)?;
 
-    let stakers = STAKERS.stakers.range_raw(deps.storage, None, None, Order::Ascending);
-    let all_active_stakers = stakers
-        .filter_map(|stakers_info| {
-            if let Ok((public_key, staker)) = stakers_info {
-                if staker.tokens_staked >= config.minimum_stake {
-                    return Some((public_key, staker));
-                }
-            }
+    if !STAKERS.is_staker_executor(deps.storage, &public_key)? {
+        return Ok(false);
+    }
 
-            None
-        })
-        .collect::<Vec<(Vec<u8>, Staker)>>();
+    let stakers = STAKERS
+        .stakers
+        .range_raw(deps.storage, None, None, Order::Ascending)
+        .flatten();
+    let blocks_passed = env.block.height - data_request.height;
 
-    let (active_staker_index, _) = all_active_stakers
-        .iter()
-        .enumerate()
-        .find(|(_, (pk, _staker))| public_key.as_ref() == pk.as_slice())
-        .expect("Could not find staker");
+    Ok(calculate_dr_eligibility(
+        stakers,
+        public_key.as_ref(),
+        config.minimum_stake,
+        dr_id,
+        data_request.replication_factor,
+        blocks_passed,
+    ))
+}
 
-    let executor_index = Uint256::from(active_staker_index as u64);
-    let executor_length = Uint256::from(all_active_stakers.len() as u64);
+/// Calculate if a staker is eligible based on their position in a deterministic ordering
+///
+/// # Arguments
+/// * `active_stakers` - Iterator of (public_key, staker) pairs
+/// * `target_public_key` - Public key to check eligibility for
+/// * `minimum_stake` - Minimum stake required to be considered active
+/// * `dr_id` - Data request ID used for deterministic selection
+/// * `replication_factor` - Initial number of nodes needed
+/// * `blocks_passed` - Number of blocks since DR was posted
+///
+/// # Algorithm
+/// 1. Filter stakers that meet minimum stake requirement
+/// 2. Compute hash for target staker using public_key + dr_id
+/// 3. Count total eligible stakers and how many have lower hash than target
+/// 4. Calculate total needed stakers (replication_factor + blocks_passed), capped by total available
+/// 5. Target is eligible if fewer stakers have lower hash than total needed
+///
+/// # Returns
+/// `true` if the staker is eligible, `false` otherwise
+fn calculate_dr_eligibility<I>(
+    active_stakers: I,
+    target_public_key: &[u8],
+    minimum_stake: Uint128,
+    dr_id: [u8; 32],
+    replication_factor: u16,
+    blocks_passed: u64,
+) -> bool
+where
+    I: Iterator<Item = (Vec<u8>, Staker)>,
+{
+    let target_hash = compute_selection_hash(target_public_key, &dr_id);
 
-    let dr_index = Uint256::from_be_bytes(dr_id) % executor_length;
-    let replication_factor = Uint256::from(data_request.replication_factor);
-    let end_index = (dr_index + replication_factor) % executor_length;
+    // Count total eligible stakers and stakers with lower hash in one pass
+    let (total_stakers, lower_hash_count) = active_stakers
+        .filter(|(_, staker)| staker.tokens_staked >= minimum_stake)
+        .fold((0, 0), |(total, lower), (public_key, _)| {
+            let staker_hash = compute_selection_hash(&public_key, &dr_id);
+            (total + 1, lower + if staker_hash < target_hash { 1 } else { 0 })
+        });
 
-    if dr_index < end_index {
-        // No overflow case
-        Ok(executor_index >= dr_index && executor_index < end_index)
-    } else {
-        // Overflow case
-        Ok(executor_index >= dr_index || executor_index < end_index)
+    if total_stakers == 0 {
+        return false;
+    }
+
+    // Calculate total needed stakers, capped by total available
+    let total_needed = replication_factor as u64 + blocks_passed;
+    let total_needed = total_needed.min(total_stakers as u64);
+
+    // Staker is eligible if their position (by hash order) is within needed range
+    lower_hash_count < total_needed as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_stakers(count: usize) -> Vec<(Vec<u8>, Staker)> {
+        (1..=count)
+            .map(|i| {
+                (
+                    vec![i as u8],
+                    Staker {
+                        tokens_staked:             Uint128::from(100u128),
+                        memo:                      None,
+                        tokens_pending_withdrawal: Uint128::from(0u128),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_node_selection_consistency() {
+        let dr_id = [1; 32];
+        let minimum_stake = Uint128::from(100u128);
+        let replication_factor = 3;
+        let blocks_passed = 2;
+        let stakers = create_test_stakers(10);
+
+        // Get selected nodes using sorting approach
+        let mut sorted_stakers = stakers.clone();
+        sorted_stakers.sort_by_cached_key(|(public_key, _)| compute_selection_hash(public_key, &dr_id));
+
+        let total_needed = (replication_factor as usize + blocks_passed as usize).min(sorted_stakers.len());
+        let selected_by_sorting: Vec<_> = sorted_stakers
+            .iter()
+            .take(total_needed)
+            .map(|(pk, _)| pk.clone())
+            .collect();
+
+        // Get selected nodes using eligibility function
+        let selected_by_eligibility: Vec<_> = stakers
+            .iter()
+            .filter(|(public_key, _)| {
+                calculate_dr_eligibility(
+                    stakers.clone().into_iter(),
+                    public_key,
+                    minimum_stake,
+                    dr_id,
+                    replication_factor,
+                    blocks_passed,
+                )
+            })
+            .map(|(pk, _)| pk.clone())
+            .collect();
+
+        // Sort both results for comparison
+        let mut sorted_by_sorting = selected_by_sorting.clone();
+        let mut sorted_by_eligibility = selected_by_eligibility.clone();
+        sorted_by_sorting.sort();
+        sorted_by_eligibility.sort();
+
+        // Verify both approaches select the same nodes
+        assert_eq!(
+            sorted_by_sorting, sorted_by_eligibility,
+            "Selected nodes don't match between sorting and eligibility approaches"
+        );
+
+        // Verify we selected the correct number of nodes
+        assert_eq!(
+            selected_by_eligibility.len(),
+            total_needed,
+            "Wrong number of nodes selected"
+        );
+
+        // Test with different dr_id to ensure selection changes
+        let different_dr_id = [2; 32];
+        let selected_with_different_dr: Vec<_> = stakers
+            .iter()
+            .filter(|(public_key, _)| {
+                calculate_dr_eligibility(
+                    stakers.clone().into_iter(),
+                    public_key,
+                    minimum_stake,
+                    different_dr_id,
+                    replication_factor,
+                    blocks_passed,
+                )
+            })
+            .map(|(pk, _)| pk.clone())
+            .collect();
+
+        assert_ne!(
+            selected_by_eligibility, selected_with_different_dr,
+            "Node selection should change with different dr_id"
+        );
+    }
+
+    #[test]
+    fn test_backup_replication_factor() {
+        let minimum_stake = Uint128::from(100u128);
+        let dr_id = [1; 32];
+        let replication_factor = 2;
+        let stakers = create_test_stakers(5);
+
+        // Test with 0 blocks passed (should use replication_factor)
+        let eligible_count = stakers
+            .iter()
+            .filter(|(public_key, _)| {
+                calculate_dr_eligibility(
+                    stakers.clone().into_iter(),
+                    public_key,
+                    minimum_stake,
+                    dr_id,
+                    replication_factor,
+                    0,
+                )
+            })
+            .count();
+        assert_eq!(eligible_count, replication_factor as usize);
+
+        // Test with 2 blocks passed (should use replication_factor + 2)
+        let eligible_count = stakers
+            .iter()
+            .filter(|(public_key, _)| {
+                calculate_dr_eligibility(
+                    stakers.clone().into_iter(),
+                    public_key,
+                    minimum_stake,
+                    dr_id,
+                    replication_factor,
+                    2,
+                )
+            })
+            .count();
+        assert_eq!(eligible_count, (replication_factor + 2) as usize);
+
+        // Test with many blocks passed (should cap at total stakers)
+        let eligible_count = stakers
+            .iter()
+            .filter(|(public_key, _)| {
+                calculate_dr_eligibility(
+                    stakers.clone().into_iter(),
+                    public_key,
+                    minimum_stake,
+                    dr_id,
+                    replication_factor,
+                    10,
+                )
+            })
+            .count();
+        assert_eq!(eligible_count, stakers.len());
     }
 }

--- a/contract/src/msgs/staking/state/is_eligible_for_dr.rs
+++ b/contract/src/msgs/staking/state/is_eligible_for_dr.rs
@@ -3,11 +3,8 @@ use sha3::{Digest, Keccak256};
 
 use super::{staking::state::STAKERS, *};
 
-/// Fixed size hash output type
-type Hash = [u8; 32];
-
 /// Compute deterministic hash for staker selection by combining public key and dr_id
-fn compute_selection_hash(public_key: &[u8], dr_id: &[u8; 32]) -> Hash {
+fn compute_selection_hash(public_key: &[u8], dr_id: &[u8]) -> Hash {
     let mut hasher = Keccak256::new();
     hasher.update(public_key);
     hasher.update(dr_id);

--- a/contract/src/test_utils.rs
+++ b/contract/src/test_utils.rs
@@ -11,7 +11,10 @@ use k256::{
     elliptic_curve::rand_core::OsRng,
 };
 use num_bigfloat::BigFloat;
-use seda_common::{msgs::*, types::ToHexStr};
+use seda_common::{
+    msgs::{staking::StakingConfig, *},
+    types::ToHexStr,
+};
 use serde::{de::DeserializeOwned, Serialize};
 use vrf_rs::Secp256k1Sha256;
 
@@ -80,7 +83,10 @@ impl TestInfo {
             token:          "aseda".to_string(),
             owner:          creator_addr.to_string(),
             chain_id:       chain_id.clone(),
-            staking_config: None,
+            staking_config: Some(StakingConfig {
+                minimum_stake:     1u128.into(),
+                allowlist_enabled: false,
+            }),
             timeout_config: None,
         };
 


### PR DESCRIPTION
# Motivation

If some executors go offline, the existing query logic could fail to resolve data requests due to insufficient commits.
This posed a risk where a subset of available executors could not fulfill the request alone, resulting in an availability risk.

# Explanation of Changes

1. The replication factor now increases incrementally with each block that passes after a data request is posted. This enables other allow-listed executors to step in if the original ones are unavailable.

2. This PR also sets default staking configuration values that align with the parameters planned for the mainnet upgrade, ensuring a smoother transition and consistent validator experience.

# Testing

Added tests for replication factor growth.

# Related PRs and Issues

N/A