### PR TITLE
Update defaults and remove legacy

### DIFF
--- a/contract/src/consts.rs
+++ b/contract/src/consts.rs
@@ -2,8 +2,8 @@ use std::num::NonZero;
 
 use cosmwasm_std::Uint128;
 
-pub const INITIAL_MINIMUM_STAKE: Uint128 = Uint128::new(10);
+pub const INITIAL_MINIMUM_STAKE: Uint128 = Uint128::new(10_000_000_000_000_000_000_000);
 
-pub const INITIAL_COMMIT_TIMEOUT_IN_BLOCKS: u64 = 10;
+pub const INITIAL_COMMIT_TIMEOUT_IN_BLOCKS: u64 = 50;
 pub const INITIAL_REVEAL_TIMEOUT_IN_BLOCKS: u64 = 5;
 pub const INITIAL_BACKUP_DELAY_IN_BLOCKS: NonZero<u64> = NonZero::new(2).unwrap();

--- a/contract/src/legacy.rs
+++ b/contract/src/legacy.rs
@@ -1,9 +1,0 @@
-use cw_storage_plus::Item;
-
-#[cosmwasm_schema::cw_serde]
-pub struct TimeoutConfig {
-    pub commit_timeout_in_blocks: u64,
-    pub reveal_timeout_in_blocks: u64,
-}
-
-pub const TIMEOUT_CONFIG: Item<TimeoutConfig> = Item::new("timeout_config");

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -6,8 +6,6 @@ pub mod state;
 mod types;
 mod utils;
 
-pub mod legacy;
-
 use seda_common::types as common_types;
 
 #[cfg(test)]

--- a/contract/src/msgs/data_requests/tests/commit_dr.rs
+++ b/contract/src/msgs/data_requests/tests/commit_dr.rs
@@ -6,7 +6,7 @@ use seda_common::{
     types::HashSelf,
 };
 
-use crate::{msgs::data_requests::test_helpers, TestInfo};
+use crate::{consts::INITIAL_COMMIT_TIMEOUT_IN_BLOCKS, msgs::data_requests::test_helpers, TestInfo};
 
 #[test]
 #[should_panic(expected = "not found")]
@@ -35,7 +35,7 @@ fn fails_if_not_staked() {
 }
 
 #[test]
-#[should_panic(expected = "DataRequestExpired(11, \"commit\")")]
+#[should_panic(expected = "DataRequestExpired(51, \"commit\")")]
 fn fails_if_timed_out() {
     let test_info = TestInfo::init();
     let alice = test_info.new_executor("alice", 22, 1);
@@ -45,7 +45,7 @@ fn fails_if_timed_out() {
     let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
 
     // set the block height to be equal to the timeout height
-    test_info.set_block_height(11);
+    test_info.set_block_height(INITIAL_COMMIT_TIMEOUT_IN_BLOCKS + 1);
 
     // commit a data result
     let alice_reveal = RevealBody {
@@ -71,7 +71,7 @@ fn fails_on_expired_dr() {
     let dr_id = anyone.post_data_request(dr, vec![], vec![], 1, None).unwrap();
 
     // set the block height to be later than the timeout
-    test_info.set_block_height(11);
+    test_info.set_block_height(INITIAL_COMMIT_TIMEOUT_IN_BLOCKS + 1);
     // expire the data request
     test_info.creator().expire_data_requests().unwrap();
 

--- a/contract/src/msgs/data_requests/tests/timeout_actions.rs
+++ b/contract/src/msgs/data_requests/tests/timeout_actions.rs
@@ -5,7 +5,11 @@ use seda_common::{
     types::HashSelf,
 };
 
-use crate::{msgs::data_requests::test_helpers, TestInfo};
+use crate::{
+    consts::{INITIAL_COMMIT_TIMEOUT_IN_BLOCKS, INITIAL_REVEAL_TIMEOUT_IN_BLOCKS},
+    msgs::data_requests::test_helpers,
+    TestInfo,
+};
 
 #[test]
 fn owner_can_update_dr_config() {
@@ -45,14 +49,16 @@ fn timed_out_requests_move_to_tally() {
     let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
 
     // set the block height to the height it would timeout
-    test_info.set_block_height(11);
+    test_info.set_block_height(INITIAL_COMMIT_TIMEOUT_IN_BLOCKS + 1);
 
     // process the timed out requests at current height
     test_info.creator().expire_data_requests().unwrap();
 
     // post another data request
     let dr2 = test_helpers::calculate_dr_id_and_args(2, 1);
-    let dr_id2 = alice.post_data_request(dr2, vec![], vec![], 11, None).unwrap();
+    let dr_id2 = alice
+        .post_data_request(dr2, vec![], vec![], INITIAL_COMMIT_TIMEOUT_IN_BLOCKS + 1, None)
+        .unwrap();
 
     // alice commits a data result
     let alice_reveal = RevealBody {
@@ -68,7 +74,7 @@ fn timed_out_requests_move_to_tally() {
 
     // set the block height to be later than the timeout so it times out during the
     // reveal phase
-    test_info.set_block_height(16);
+    test_info.set_block_height(INITIAL_COMMIT_TIMEOUT_IN_BLOCKS + INITIAL_REVEAL_TIMEOUT_IN_BLOCKS + 1);
 
     // process the timed out requests at current height
     test_info.creator().expire_data_requests().unwrap();


### PR DESCRIPTION
## Motivation

Since all deployed contracts are on the latest version we'll never need
    the migration logic again.

With the defaults at the values we decided on we won't need to immediately change the settings after deploying on mainnet.

## Explanation of Changes

N.A.

## Testing

Updated unit tests.

## Related PRs and Issues

N.A.