### PR TITLE
refactor: separate reveal storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 
 [features]

--- a/common/src/msgs/data_requests/query.rs
+++ b/common/src/msgs/data_requests/query.rs
@@ -15,7 +15,7 @@ pub enum QueryMsg {
     },
     #[cfg_attr(feature = "cosmwasm", returns(bool))]
     CanExecutorReveal { dr_id: String, public_key: String },
-    #[cfg_attr(feature = "cosmwasm", returns(Option<DataRequest>))]
+    #[cfg_attr(feature = "cosmwasm", returns(Option<DataRequestResponse>))]
     GetDataRequest { dr_id: String },
     #[cfg_attr(feature = "cosmwasm",  returns(Option<String>))]
     GetDataRequestCommitment { dr_id: String, public_key: String },

--- a/common/src/msgs/data_requests/types_tests.rs
+++ b/common/src/msgs/data_requests/types_tests.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, num::NonZero};
 
 use serde_json::json;
 
-use super::{DataRequest, DrConfig, PostDataRequestArgs, RevealBody};
+use super::*;
 #[cfg(feature = "cosmwasm")]
 use crate::msgs::assert_json_deser;
 use crate::{msgs::assert_json_ser, types::*};
@@ -25,7 +25,7 @@ fn data_request_id_vector() {
 }
 
 #[test]
-fn json_data_request() {
+fn json_data_request_response() {
     let id = "id".to_string();
     let version = "1.0.0".to_string();
     let exec_program_id = "exec_program_id".to_string();
@@ -82,30 +82,38 @@ fn json_data_request() {
       "height": height,
     });
 
-    let msg = DataRequest {
-        id,
-        version: version.parse().unwrap(),
-        exec_program_id,
-        exec_inputs,
-        exec_gas_limit,
-        tally_program_id,
-        tally_inputs,
-        tally_gas_limit,
-        replication_factor,
-        consensus_filter,
-        gas_price,
-        memo,
-        payback_address,
-        seda_payload,
-        commits,
+    let msg = DataRequestResponse {
+        base: DataRequestBase {
+            id,
+            version: version.parse().unwrap(),
+            exec_program_id,
+            exec_inputs,
+            exec_gas_limit,
+            tally_program_id,
+            tally_inputs,
+            tally_gas_limit,
+            replication_factor,
+            consensus_filter,
+            gas_price,
+            memo,
+            payback_address,
+            seda_payload,
+            commits,
+            height,
+        },
         reveals,
-        height,
     };
 
     #[cfg(not(feature = "cosmwasm"))]
-    assert_json_ser(msg, expected_json);
+    assert_json_ser(msg.clone(), expected_json.clone());
     #[cfg(feature = "cosmwasm")]
     assert_json_deser(msg, expected_json);
+
+    #[cfg(not(feature = "cosmwasm"))]
+    {
+        let dr_response: DataRequestResponse = serde_json::from_value(expected_json).unwrap();
+        assert_eq!(msg, dr_response);
+    }
 }
 
 #[test]

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.4"
+version = "1.0.5"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -91,26 +91,28 @@ impl ExecuteHandler for execute::post_request::Execute {
             ]));
 
         // save the data request
-        let dr = DataRequest {
-            id:                 hex_dr_id,
-            version:            self.posted_dr.version,
-            exec_program_id:    self.posted_dr.exec_program_id,
-            exec_inputs:        self.posted_dr.exec_inputs,
-            exec_gas_limit:     self.posted_dr.exec_gas_limit,
-            tally_program_id:   self.posted_dr.tally_program_id,
-            tally_inputs:       self.posted_dr.tally_inputs,
-            tally_gas_limit:    self.posted_dr.tally_gas_limit,
-            replication_factor: self.posted_dr.replication_factor,
-            consensus_filter:   self.posted_dr.consensus_filter,
-            gas_price:          self.posted_dr.gas_price,
-            memo:               self.posted_dr.memo,
+        let dr = DataRequestContract {
+            base:    DataRequestBase {
+                id:                 hex_dr_id,
+                version:            self.posted_dr.version,
+                exec_program_id:    self.posted_dr.exec_program_id,
+                exec_inputs:        self.posted_dr.exec_inputs,
+                exec_gas_limit:     self.posted_dr.exec_gas_limit,
+                tally_program_id:   self.posted_dr.tally_program_id,
+                tally_inputs:       self.posted_dr.tally_inputs,
+                tally_gas_limit:    self.posted_dr.tally_gas_limit,
+                replication_factor: self.posted_dr.replication_factor,
+                consensus_filter:   self.posted_dr.consensus_filter,
+                gas_price:          self.posted_dr.gas_price,
+                memo:               self.posted_dr.memo,
 
-            payback_address: self.payback_address,
-            seda_payload:    self.seda_payload,
-            commits:         Default::default(),
-            reveals:         Default::default(),
+                payback_address: self.payback_address,
+                seda_payload:    self.seda_payload,
+                commits:         Default::default(),
 
-            height: env.block.height,
+                height: env.block.height,
+            },
+            reveals: Default::default(),
         };
         state::post_request(deps.storage, env.block.height, &dr_id, dr)?;
 

--- a/contract/src/msgs/data_requests/execute/reveal_result.rs
+++ b/contract/src/msgs/data_requests/execute/reveal_result.rs
@@ -75,7 +75,8 @@ impl ExecuteHandler for execute::reveal_result::Execute {
             &dr_id,
             dr,
             env.block.height,
-            (&format!("{dr_id_str}:{}", self.public_key), self.reveal_body),
+            &self.public_key,
+            self.reveal_body,
         )?;
 
         Ok(response.add_message(new_refund_msg(env, dr_id_str, self.public_key, true)?))

--- a/contract/src/msgs/data_requests/query.rs
+++ b/contract/src/msgs/data_requests/query.rs
@@ -36,9 +36,10 @@ impl QueryHandler for QueryMsg {
                 to_json_binary(&can_reveal.unwrap_or(false))?
             }
             QueryMsg::GetDataRequest { dr_id } => {
-                match state::may_load_request(deps.storage, &Hash::from_hex_str(&dr_id)?)? {
+                let dr_id = &Hash::from_hex_str(&dr_id)?;
+                match state::may_load_request(deps.storage, dr_id)? {
                     Some(dr) => to_json_binary(&DataRequestResponse {
-                        reveals: state::get_reveals(deps.storage, &dr.base.id)?,
+                        reveals: state::get_reveals(deps.storage, dr_id)?,
                         base:    dr.base,
                     })?,
                     None => to_json_binary(&None::<DataRequestResponse>)?,
@@ -54,8 +55,9 @@ impl QueryHandler for QueryMsg {
                 to_json_binary(&commitments)?
             }
             QueryMsg::GetDataRequestReveal { dr_id, public_key } => {
-                if (state::may_load_request(deps.storage, &Hash::from_hex_str(&dr_id)?)?).is_some() {
-                    if let Some(reveal) = state::get_reveal(deps.storage, &format!("{dr_id}:{public_key}"))? {
+                let dr_id = &Hash::from_hex_str(&dr_id)?;
+                if (state::may_load_request(deps.storage, dr_id)?).is_some() {
+                    if let Some(reveal) = state::get_reveal(deps.storage, dr_id, &public_key)? {
                         to_json_binary(&reveal)?;
                     }
                 }

--- a/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
@@ -31,7 +31,7 @@ impl TestInfo<'_> {
 
     #[track_caller]
     pub fn assert_dr_reveals_len(&self, expected: usize, dr_id: &Hash) {
-        let reveals = self.map.get_reveals(&self.store, &dr_id.to_hex()).unwrap();
+        let reveals = self.map.get_reveals(&self.store, dr_id).unwrap();
         assert_eq!(expected, reveals.len());
     }
 
@@ -104,7 +104,7 @@ impl TestInfo<'_> {
 
     #[track_caller]
     fn remove(&mut self, key: &Hash) {
-        self.map.remove(&mut self.store, key, &key.to_hex()).unwrap();
+        self.map.remove(&mut self.store, key).unwrap();
     }
 
     #[track_caller]
@@ -407,7 +407,7 @@ fn reveal() {
     let (key, req) = create_test_dr(1);
     test_info.insert_removable(1, &key, req.clone());
 
-    let reveal_key = format!("{}:{}", key.to_hex(), 1);
+    let identity = "identity";
     let reveal_body = RevealBody {
         dr_id:             "dr_id".to_string(),
         dr_block_height:   1,
@@ -418,20 +418,20 @@ fn reveal() {
     };
     test_info
         .map
-        .insert_reveal(&mut test_info.store, &reveal_key, reveal_body.clone())
+        .insert_reveal(&mut test_info.store, &key, identity, reveal_body.clone())
         .unwrap();
 
     test_info.assert_dr_reveals_len(1, &key);
 
     let reveal = test_info
         .map
-        .get_reveal(&test_info.store, &reveal_key)
+        .get_reveal(&test_info.store, &key, identity)
         .unwrap()
         .unwrap();
     assert_eq!(reveal, reveal_body);
 
-    let reveals = test_info.map.get_reveals(&test_info.store, &key.to_hex()).unwrap();
+    let reveals = test_info.map.get_reveals(&test_info.store, &key).unwrap();
     assert_eq!(reveals.len(), 1);
 
-    test_info.map.remove(&mut test_info.store, &key, &reveal_key).unwrap();
+    test_info.map.remove(&mut test_info.store, &key).unwrap();
 }

--- a/contract/src/msgs/data_requests/state/mod.rs
+++ b/contract/src/msgs/data_requests/state/mod.rs
@@ -84,7 +84,8 @@ pub fn reveal(
     dr_id: &Hash,
     dr: DataRequestContract,
     current_height: u64,
-    (reveal_key, reveal_body): (&str, RevealBody),
+    identity: &str,
+    reveal_body: RevealBody,
 ) -> StdResult<()> {
     let status = if dr.is_tallying() {
         // We update the status of the request from Revealing to Tallying
@@ -94,22 +95,22 @@ pub fn reveal(
         None
     };
     DATA_REQUESTS.update(store, dr_id, dr, status, current_height, false)?;
-    DATA_REQUESTS.insert_reveal(store, reveal_key, reveal_body)?;
+    DATA_REQUESTS.insert_reveal(store, dr_id, identity, reveal_body)?;
 
     Ok(())
 }
 
-pub fn get_reveal(store: &dyn Storage, reveal_key: &str) -> StdResult<Option<RevealBody>> {
-    DATA_REQUESTS.get_reveal(store, reveal_key)
+pub fn get_reveal(store: &dyn Storage, dr_id: &Hash, identity: &str) -> StdResult<Option<RevealBody>> {
+    DATA_REQUESTS.get_reveal(store, dr_id, identity)
 }
 
-pub fn get_reveals(store: &dyn Storage, dr_id: &str) -> StdResult<HashMap<String, RevealBody>> {
+pub fn get_reveals(store: &dyn Storage, dr_id: &Hash) -> StdResult<HashMap<String, RevealBody>> {
     DATA_REQUESTS.get_reveals(store, dr_id)
 }
 
-pub fn remove_request(store: &mut dyn Storage, dr_id: &Hash, dr_id_str: &str) -> StdResult<()> {
+pub fn remove_request(store: &mut dyn Storage, dr_id: &Hash) -> StdResult<()> {
     // we have to remove the request from the pool
-    DATA_REQUESTS.remove(store, dr_id, dr_id_str)?;
+    DATA_REQUESTS.remove(store, dr_id)?;
     // no need to update status as we remove it from the requests pool
 
     Ok(())

--- a/contract/src/msgs/data_requests/sudo/remove_requests.rs
+++ b/contract/src/msgs/data_requests/sudo/remove_requests.rs
@@ -74,7 +74,7 @@ fn remove_request_and_process_distributions(
 
     event = event.add_attributes([
         ("dr_id", dr_id_str.clone()),
-        ("posted_dr_height", dr.height.to_string()),
+        ("posted_dr_height", dr.base.height.to_string()),
     ]);
 
     // add 1 so we can account for the refund message that may be sent
@@ -199,7 +199,7 @@ fn remove_request_and_process_distributions(
         event = event.add_attribute("refund", dr_escrow.amount.to_string());
     }
 
-    if state::remove_request(deps.storage, &dr_id).is_err() {
+    if state::remove_request(deps.storage, &dr_id, &dr_id_str).is_err() {
         event = event.add_attribute("failed_to_remove_dr", dr_id_str);
     };
     DR_ESCROW.remove(deps.storage, &dr_id);

--- a/contract/src/msgs/data_requests/sudo/remove_requests.rs
+++ b/contract/src/msgs/data_requests/sudo/remove_requests.rs
@@ -199,7 +199,7 @@ fn remove_request_and_process_distributions(
         event = event.add_attribute("refund", dr_escrow.amount.to_string());
     }
 
-    if state::remove_request(deps.storage, &dr_id, &dr_id_str).is_err() {
+    if state::remove_request(deps.storage, &dr_id).is_err() {
         event = event.add_attribute("failed_to_remove_dr", dr_id_str);
     };
     DR_ESCROW.remove(deps.storage, &dr_id);

--- a/contract/src/msgs/data_requests/tests/commit_dr.rs
+++ b/contract/src/msgs/data_requests/tests/commit_dr.rs
@@ -152,7 +152,7 @@ fn works() {
     let commiting = alice.get_data_requests_by_status(DataRequestStatus::Committing, None, 10);
     assert!(!commiting.is_paused);
     assert_eq!(1, commiting.data_requests.len());
-    assert!(commiting.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(commiting.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 #[test]
 fn must_meet_replication_factor() {
@@ -180,7 +180,7 @@ fn must_meet_replication_factor() {
     let revealing = anyone.get_data_requests_by_status(DataRequestStatus::Revealing, None, 10);
     assert!(!revealing.is_paused);
     assert_eq!(1, revealing.data_requests.len());
-    assert!(revealing.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(revealing.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]

--- a/contract/src/msgs/data_requests/tests/post_dr.rs
+++ b/contract/src/msgs/data_requests/tests/post_dr.rs
@@ -43,11 +43,14 @@ fn works() {
 
     // should be able to fetch data request with id 0x69...
     let received_value = anyone.get_data_request(&dr_id);
-    assert_eq!(Some(test_helpers::construct_dr(dr, vec![], 1)), received_value);
+    assert_eq!(
+        Some(test_helpers::construct_dr(dr, vec![], 1).base),
+        received_value.map(|dr| dr.base)
+    );
     let await_commits = anyone.get_data_requests_by_status(DataRequestStatus::Committing, None, 10);
     assert!(!await_commits.is_paused);
     assert_eq!(1, await_commits.data_requests.len());
-    assert!(await_commits.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(await_commits.data_requests.iter().any(|r| r.base.id == dr_id));
 
     // nonexistent data request does not yet exist
     let value = anyone.get_data_request("00f0f00f0f00f0f0000000f0fff0ff0ff0ffff0fff00000f000ff000000f000f");

--- a/contract/src/msgs/data_requests/tests/query_dr_status.rs
+++ b/contract/src/msgs/data_requests/tests/query_dr_status.rs
@@ -31,7 +31,7 @@ fn one_works() {
     let drs = anyone.get_data_requests_by_status(DataRequestStatus::Committing, None, 10);
     assert!(!drs.is_paused);
     assert_eq!(1, drs.data_requests.len());
-    assert!(drs.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(drs.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn offset_works() {
 
     let drs_one = anyone.get_data_requests_by_status(DataRequestStatus::Committing, None, 1);
     assert_eq!(1, drs_one.data_requests.len());
-    assert!(drs_one.data_requests.iter().any(|dr| dr.id == posted_dr1));
+    assert!(drs_one.data_requests.iter().any(|dr| dr.base.id == posted_dr1));
     assert_eq!(drs_one.last_seen_index.map(|(_, h, _)| h), Some(u64::MAX - 1));
 
     let drs = anyone.get_data_requests_by_status(DataRequestStatus::Committing, drs_one.last_seen_index, 2);
@@ -195,7 +195,7 @@ fn works_with_many_more_drs_in_pool() {
     {
         if i % 4 == 0 {
             let alice_reveal = RevealBody {
-                dr_id:             request.id.clone(),
+                dr_id:             request.base.id.clone(),
                 dr_block_height:   1,
                 reveal:            "10".hash().into(),
                 gas_used:          0,
@@ -242,7 +242,7 @@ fn works_with_many_more_drs_in_pool() {
         if i % 8 == 0 {
             alice
                 .remove_data_request(
-                    request.id.to_string(),
+                    request.base.id.to_string(),
                     vec![DistributionMessage::ExecutorReward(DistributionExecutorReward {
                         amount:   10u128.into(),
                         identity: alice.pub_key_hex(),

--- a/contract/src/msgs/data_requests/tests/remove_dr.rs
+++ b/contract/src/msgs/data_requests/tests/remove_dr.rs
@@ -347,14 +347,14 @@ fn works_with_more_drs_in_the_pool() {
     let dr_to_be_tallied = alice.get_data_requests_by_status(DataRequestStatus::Tallying, None, 100);
     assert!(!dr_to_be_tallied.is_paused);
     assert_eq!(1, dr_to_be_tallied.data_requests.len());
-    assert_eq!(dr_to_be_tallied.data_requests[0].id, dr_id1);
+    assert_eq!(dr_to_be_tallied.data_requests[0].base.id, dr_id1);
 
     // Remove only first dr ready to be tallied (while there is another one in the
     // pool and not ready) This checks part of the swap_remove logic
     let dr = dr_to_be_tallied.data_requests[0].clone();
     alice
         .remove_data_request(
-            dr.id,
+            dr.base.id,
             vec![DistributionMessage::ExecutorReward(DistributionExecutorReward {
                 amount:   10u128.into(),
                 identity: alice.pub_key_hex(),
@@ -379,7 +379,7 @@ fn works_with_more_drs_in_the_pool() {
     let dr = dr_to_be_tallied.data_requests[0].clone();
     alice
         .remove_data_request(
-            dr.id,
+            dr.base.id,
             vec![DistributionMessage::ExecutorReward(DistributionExecutorReward {
                 amount:   10u128.into(),
                 identity: alice.pub_key_hex(),

--- a/contract/src/msgs/data_requests/tests/reveal_dr.rs
+++ b/contract/src/msgs/data_requests/tests/reveal_dr.rs
@@ -53,7 +53,7 @@ fn works() {
     let revealing = alice.get_data_requests_by_status(DataRequestStatus::Revealing, None, 10);
     assert!(!revealing.is_paused);
     assert_eq!(1, revealing.data_requests.len());
-    assert!(revealing.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(revealing.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn works_with_proxies() {
     let tallying = alice.get_data_requests_by_status(DataRequestStatus::Tallying, None, 10);
     assert!(!tallying.is_paused);
     assert_eq!(1, tallying.data_requests.len());
-    assert!(tallying.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(tallying.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn fails_if_user_did_not_commit() {
     let revealing = alice.get_data_requests_by_status(DataRequestStatus::Revealing, None, 10);
     assert!(!revealing.is_paused);
     assert_eq!(1, revealing.data_requests.len());
-    assert!(revealing.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(revealing.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]
@@ -349,7 +349,7 @@ fn fails_if_does_not_match_commitment() {
     let revealing = alice.get_data_requests_by_status(DataRequestStatus::Revealing, None, 10);
     assert!(!revealing.is_paused);
     assert_eq!(1, revealing.data_requests.len());
-    assert!(revealing.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(revealing.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]
@@ -420,7 +420,7 @@ fn works_after_unstaking() {
     let tallying = alice.get_data_requests_by_status(DataRequestStatus::Tallying, None, 10);
     assert!(!tallying.is_paused);
     assert_eq!(1, tallying.data_requests.len());
-    assert!(tallying.data_requests.iter().any(|r| r.id == dr_id));
+    assert!(tallying.data_requests.iter().any(|r| r.base.id == dr_id));
 }
 
 #[test]

--- a/contract/src/msgs/data_requests/tests/timeout_actions.rs
+++ b/contract/src/msgs/data_requests/tests/timeout_actions.rs
@@ -84,7 +84,7 @@ fn timed_out_requests_move_to_tally() {
         .get_data_requests_by_status(DataRequestStatus::Tallying, None, 10)
         .data_requests
         .into_iter()
-        .map(|r| r.id)
+        .map(|r| r.base.id)
         .collect::<Vec<_>>();
     assert_eq!(2, tallying.len());
     assert_eq!(tallying[0], dr_id);

--- a/contract/src/msgs/staking/state/is_eligible_for_dr.rs
+++ b/contract/src/msgs/staking/state/is_eligible_for_dr.rs
@@ -39,7 +39,7 @@ pub fn is_eligible_for_dr(deps: Deps, env: Env, dr_id: [u8; 32], public_key: Pub
         .stakers
         .range_raw(deps.storage, None, None, Order::Ascending)
         .flatten();
-    let blocks_passed = env.block.height - data_request.height;
+    let blocks_passed = env.block.height - data_request.base.height;
     let dr_config = DR_CONFIG.load(deps.storage)?;
 
     Ok(calculate_dr_eligibility(
@@ -48,7 +48,7 @@ pub fn is_eligible_for_dr(deps: Deps, env: Env, dr_id: [u8; 32], public_key: Pub
         config.minimum_stake,
         dr_config.backup_delay_in_blocks,
         dr_id,
-        data_request.replication_factor,
+        data_request.base.replication_factor,
         blocks_passed,
     ))
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use rand::Rng;
 use seda_common::{
-    msgs::data_requests::{DataRequest, RevealBody},
+    msgs::data_requests::{DataRequestBase, DataRequestResponse, RevealBody},
     types::{ToHexStr, TryHashSelf},
 };
 use serde_json::json;
@@ -112,35 +112,37 @@ fn create_data_request(
     replication_factor: u16,
     tally_inputs: Vec<u8>,
     reveals: HashMap<String, RevealBody>,
-) -> DataRequest {
-    DataRequest {
-        version: semver::Version {
-            major: 1,
-            minor: 0,
-            patch: 0,
-            pre:   semver::Prerelease::EMPTY,
-            build: semver::BuildMetadata::EMPTY,
+) -> DataRequestResponse {
+    DataRequestResponse {
+        base: DataRequestBase {
+            version: semver::Version {
+                major: 1,
+                minor: 0,
+                patch: 0,
+                pre:   semver::Prerelease::EMPTY,
+                build: semver::BuildMetadata::EMPTY,
+            },
+            id: id.to_hex(),
+            exec_program_id: exec_program_id.to_hex(),
+            exec_inputs: Default::default(),
+            exec_gas_limit: 10,
+            tally_program_id: tally_program_id.to_hex(),
+            tally_inputs: tally_inputs.into(),
+            tally_gas_limit: 20,
+            memo: Default::default(),
+            replication_factor,
+            consensus_filter: Default::default(),
+            gas_price: 10u128.into(),
+            seda_payload: Default::default(),
+            commits: Default::default(),
+            payback_address: Default::default(),
+            height: rand::random(),
         },
-        id: id.to_hex(),
-        exec_program_id: exec_program_id.to_hex(),
-        exec_inputs: Default::default(),
-        exec_gas_limit: 10,
-        tally_program_id: tally_program_id.to_hex(),
-        tally_inputs: tally_inputs.into(),
-        tally_gas_limit: 20,
-        memo: Default::default(),
-        replication_factor,
-        consensus_filter: Default::default(),
-        gas_price: 10u128.into(),
-        seda_payload: Default::default(),
-        commits: Default::default(),
         reveals,
-        payback_address: Default::default(),
-        height: rand::random(),
     }
 }
 
-fn tally_test_fixture(n: usize) -> Vec<DataRequest> {
+fn tally_test_fixture(n: usize) -> Vec<DataRequestResponse> {
     let exec_program_id: [u8; 32] = rand::random();
     let tally_program_id: [u8; 32] = rand::random();
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So that revealers don't run into gas issues.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Adds a new field reveals to the `DataRequestsMap` which contains the reveals for all DRs.
  - They are keyed by `dr_id:identity`.
- `DataRequest` struct has been changed:
  - `DataRequestBase` which has all the fields but the reveals.
  - `DataRequestContract` where the reveals field is a `HashSet` of identities that have revealed and it composes the base.
  - `DataRequestResponse` where the reveals field is the original `HashMap` and it composes the base, and preserves the same JSON serialization and de-serialization.
  - The old methods have been split among these types, but functionally remain the same.
- New methods to manage create, read, and delete operations for said reveals.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

- All old tests still pass with the only changed logic being accessing old fields/methods with `.base`
- Tests serialization and de-serialization remains the same outside the contract.
- Add tests to see reveals section works properly on DR Map.

## Dependency Chain
[chain]: https://github.com/sedaprotocol/seda-chain
[explorer]: https://github.com/sedaprotocol/seda-explorer
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[sdk]: https://github.com/sedaprotocol/seda-sdk

Think about the changes(msgs, events, limits, etc.) made in this PR and see if you need to make an issue/pr on the following repos.

- [ ] [chain][chain]
- [ ] [explorer/indexer][explorer]
- [ ] [overlay-ts][overlay-ts]: minor changes required here to just use the `DataRequestResponse` type. i.e. use `.base` where appropriate.
- [ ] [overlay-rs][overlay-rs]
- [ ] [sdk][sdk]

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A