### PR TITLE
Wait the backup delay for every additional executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.6"
+version = "1.0.7"
 edition.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
## Motivation

Given that the backup delay is intended to give executors a chance to execute the data request and commit their result, it makes sense that executors that become avaible due to the backup replication factor also get the chance to execute the DR. When executors became available at every block we saw that this lead to a lot of executor work being wasted, especially under higher loads, contributing to even more congestion.

## Explanation of Changes

Simply dividing the passed blocks by the delay (while accounting for the 'extra block' needed at the start) gives us the amount of additional executors.

## Testing

Updated the tests.

## Related PRs and Issues

N.A.