### PR TITLE
Feat/get executor eligibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 
 [features]

--- a/common/src/msgs/staking/query/mod.rs
+++ b/common/src/msgs/staking/query/mod.rs
@@ -15,6 +15,8 @@ pub enum QueryMsg {
     IsStakerExecutor { public_key: String },
     #[cfg_attr(feature = "cosmwasm", returns(bool))]
     IsExecutorEligible(is_executor_eligible::Query),
+    #[cfg_attr(feature = "cosmwasm", returns(crate::msgs::staking::GetExecutorEligibilityResponse))]
+    GetExecutorEligibility(is_executor_eligible::Query),
     #[cfg_attr(feature = "cosmwasm", returns(crate::msgs::staking::StakingConfig))]
     GetStakingConfig {},
     #[cfg_attr(feature = "cosmwasm", returns(crate::msgs::staking::GetExecutorsResponse))]

--- a/common/src/msgs/staking/types.rs
+++ b/common/src/msgs/staking/types.rs
@@ -65,3 +65,34 @@ pub struct Executor {
 pub struct GetExecutorsResponse {
     pub executors: Vec<Executor>,
 }
+
+/// Response for the `GetExecutorEligibility` query
+#[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
+#[cfg_attr(
+    not(feature = "cosmwasm"),
+    derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)
+)]
+pub struct GetExecutorEligibilityResponse {
+    pub status:       ExecutorEligibilityStatus,
+    pub block_height: u64,
+}
+
+/// Status codes for executor eligibility
+#[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
+#[cfg_attr(
+    not(feature = "cosmwasm"),
+    derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)
+)]
+#[repr(u8)]
+pub enum ExecutorEligibilityStatus {
+    /// Executor is eligible for the data request
+    Eligible            = 0,
+    /// Executor is not eligible for the data request
+    NotEligible         = 1,
+    /// Data request not found
+    DataRequestNotFound = 2,
+    /// Executor is not a staker
+    NotStaker           = 3,
+    /// Invalid signature
+    InvalidSignature    = 4,
+}

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.7"
+version = "1.0.8"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/msgs/staking/test_helpers.rs
+++ b/contract/src/msgs/staking/test_helpers.rs
@@ -1,4 +1,4 @@
-use seda_common::msgs::staking::GetExecutorsResponse;
+use seda_common::msgs::staking::{GetExecutorEligibilityResponse, GetExecutorsResponse};
 
 use super::{
     msgs::staking::{execute, query},
@@ -164,6 +164,23 @@ impl TestAccount {
         let (query, _) = factory.create_message(proof);
 
         self.test_info.query(query).unwrap()
+    }
+
+    #[track_caller]
+    pub fn is_executor_eligible_v2(&self, dr_id: String) -> GetExecutorEligibilityResponse {
+        let factory = query::is_executor_eligible::Query::factory(
+            self.pub_key_hex(),
+            dr_id,
+            self.test_info.chain_id(),
+            self.test_info.contract_addr_str(),
+        );
+        let proof = self.prove(factory.get_hash());
+        let (_, data) = factory.create_message(proof);
+        let query_inner = query::is_executor_eligible::Query { data };
+
+        self.test_info
+            .query(query::QueryMsg::GetExecutorEligibility(query_inner))
+            .unwrap()
     }
 
     #[track_caller]


### PR DESCRIPTION
## Motivation

We experienced some invalid proofs on the data proxy and overlay. We suspect that the data proxies might behind in the block height.

## Explanation of Changes

We add a new `GetExecutorEligbility` query that returns the status code of its eligibility:

```rust
pub enum ExecutorEligibilityStatus {
    /// Executor is eligible for the data request
    Eligible            = 0,
    /// Executor is not eligible for the data request
    NotEligible         = 1,
    /// Data request not found
    DataRequestNotFound = 2,
    /// Executor is not a staker
    NotStaker           = 3,
    /// Invalid signature
    InvalidSignature    = 4,
}
```

## Testing

Added tests for all cases.

## Dependency Chain
[chain]: https://github.com/sedaprotocol/seda-chain
[explorer]: https://github.com/sedaprotocol/seda-explorer
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[sdk]: https://github.com/sedaprotocol/seda-sdk

Think about the changes(msgs, events, limits, etc.) made in this PR and see if you need to make an issue/pr on the following repos.

## Related PRs and Issues

We need to add this to the data proxy so it can get a better eligibility status when querying.