### PR TITLE
Separate errors for insufficient funds and insufficient stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2021"
 rust-version.workspace = true
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.11"
+version = "1.0.12"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -37,6 +37,8 @@ pub enum ContractError {
     InvalidAddress(String),
     #[error("InsufficientFunds: Insufficient funds. Required: {0}, available: {1}")]
     InsufficientFunds(Uint128, Uint128),
+    #[error("InsufficientStake: Stake amount is insufficient. Required: {0}, got: {1}")]
+    InsufficientStake(Uint128, Uint128),
     #[error("DataRequestAlreadyExists: Data request already exists")]
     DataRequestAlreadyExists,
     #[error("DataRequestReplicationFactorZero: Data request replication factor cannot be zero")]

--- a/contract/src/msgs/data_requests/execute/commit_result.rs
+++ b/contract/src/msgs/data_requests/execute/commit_result.rs
@@ -68,7 +68,7 @@ pub fn verify_commit(
     // Check if the staker has enough funds staked to commit
     let minimum_stake = STAKING_CONFIG.load(deps.storage)?.minimum_stake;
     if staker.tokens_staked < minimum_stake {
-        return Err(ContractError::InsufficientFunds(minimum_stake, staker.tokens_staked));
+        return Err(ContractError::InsufficientStake(minimum_stake, staker.tokens_staked));
     }
 
     // verify the proof

--- a/contract/src/msgs/data_requests/tests/commit_dr.rs
+++ b/contract/src/msgs/data_requests/tests/commit_dr.rs
@@ -89,7 +89,7 @@ fn fails_on_expired_dr() {
 }
 
 #[test]
-#[should_panic(expected = "InsufficientFunds")]
+#[should_panic(expected = "InsufficientStake")]
 fn fails_if_not_enough_staked() {
     let test_info = TestInfo::init();
 

--- a/contract/src/msgs/staking/execute/stake.rs
+++ b/contract/src/msgs/staking/execute/stake.rs
@@ -26,7 +26,7 @@ impl ExecuteHandler for execute::stake::Execute {
             None => {
                 let minimum_stake_to_register = state::STAKING_CONFIG.load(deps.storage)?.minimum_stake;
                 if amount < minimum_stake_to_register {
-                    return Err(ContractError::InsufficientFunds(minimum_stake_to_register, amount));
+                    return Err(ContractError::InsufficientStake(minimum_stake_to_register, amount));
                 }
 
                 let executor = Staker {
@@ -41,7 +41,7 @@ impl ExecuteHandler for execute::stake::Execute {
             Some(mut executor) => {
                 let minimum_stake_to_register = state::STAKING_CONFIG.load(deps.storage)?.minimum_stake;
                 if amount + executor.tokens_staked < minimum_stake_to_register {
-                    return Err(ContractError::InsufficientFunds(minimum_stake_to_register, amount));
+                    return Err(ContractError::InsufficientStake(minimum_stake_to_register, amount));
                 }
                 executor.tokens_staked += amount;
 


### PR DESCRIPTION
Provides a clearer error message by distinguishing between insufficient stake vs insufficient attached funds.