### PR TITLE
fix: initial backup delay value was wrong

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.13"
+version = "1.0.14"
 edition = "2021"
 rust-version.workspace = true
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.13"
+version = "1.0.14"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/consts.rs
+++ b/contract/src/consts.rs
@@ -9,7 +9,7 @@ pub const INITIAL_MINIMUM_STAKE: Uint128 = Uint128::new(10_000_000_000_000_000_0
 pub const INITIAL_DR_CONFIG: DrConfig = DrConfig {
     commit_timeout_in_blocks:        NonZero::new(50).unwrap(),
     reveal_timeout_in_blocks:        NonZero::new(5).unwrap(),
-    backup_delay_in_blocks:          NonZero::new(2).unwrap(),
+    backup_delay_in_blocks:          NonZero::new(5).unwrap(),
     // 24 KB
     dr_reveal_size_limit_in_bytes:   NonZero::new(24_000).unwrap(),
     // 2 KB,


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Update this to match the values we've been using on testnet.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Update backup_delay to be 5 blocks.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

All tests still pass

## Dependency Chain
[chain]: https://github.com/sedaprotocol/seda-chain
[explorer]: https://github.com/sedaprotocol/seda-explorer
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[sdk]: https://github.com/sedaprotocol/seda-sdk

Think about the changes(msgs, events, limits, etc.) made in this PR and see if you need to make an issue/pr on the following repos.

- [ ] [chain][chain]
- [ ] [explorer/indexer][explorer]
- [ ] [overlay-ts][overlay-ts]
- [ ] [overlay-rs][overlay-rs]
- [ ] [sdk][sdk]

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A