### PR TITLE
feat: posted gas price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 rust-version.workspace = true
 

--- a/common/src/msgs/data_requests/types.rs
+++ b/common/src/msgs/data_requests/types.rs
@@ -68,6 +68,10 @@ pub struct DataRequestBase {
 
     /// The height data request was posted. Used for commitment.
     pub height: u64,
+
+    /// The actual gas price derived from the funds sent (funds /
+    /// total_gas_limit). This may be higher than the minimum gas_price.
+    pub posted_gas_price: U128,
 }
 
 impl DataRequestBase {

--- a/common/src/msgs/data_requests/types_tests.rs
+++ b/common/src/msgs/data_requests/types_tests.rs
@@ -61,6 +61,7 @@ fn json_data_request_response() {
     let commits = HashMap::from([("key".to_string(), "value".hash())]);
     let reveals = HashMap::new();
     let height = 1;
+    let posted_gas_price = gas_price;
 
     let expected_json = json!({
       "id": id,
@@ -80,6 +81,7 @@ fn json_data_request_response() {
       "commits": commits,
       "reveals": {},
       "height": height,
+      "posted_gas_price": posted_gas_price,
     });
 
     let msg = DataRequestResponse {
@@ -100,6 +102,7 @@ fn json_data_request_response() {
             seda_payload,
             commits,
             height,
+            posted_gas_price,
         },
         reveals,
     };

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.14"
+version = "1.0.15"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/msgs/data_requests/consts.rs
+++ b/contract/src/msgs/data_requests/consts.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::Uint128;
 
 const TERA_GAS: u64 = 1_000_000_000_000;
 
-pub const MIN_GAS_PRICE: Uint128 = Uint128::new(1_000);
+pub const MIN_GAS_PRICE: Uint128 = Uint128::new(2_000);
 pub const MIN_EXEC_GAS_LIMIT: u64 = 10 * TERA_GAS;
 pub const MIN_TALLY_GAS_LIMIT: u64 = 10 * TERA_GAS;
 

--- a/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
+++ b/contract/src/msgs/data_requests/state/data_requests_map_tests.rs
@@ -123,7 +123,11 @@ impl TestInfo<'_> {
 
 fn create_test_dr(height: u64) -> (Hash, DataRequestContract) {
     let args = calculate_dr_id_and_args(height as u128, 2);
-    let dr = construct_dr(args, vec![], height);
+    let min_amount = args
+        .gas_price
+        .checked_mul(Uint128::from(args.exec_gas_limit + args.tally_gas_limit))
+        .unwrap();
+    let dr = construct_dr(args, vec![], height, min_amount.into());
 
     (Hash::from_hex_str(&dr.base.id).unwrap(), dr)
 }

--- a/contract/src/msgs/data_requests/test_helpers.rs
+++ b/contract/src/msgs/data_requests/test_helpers.rs
@@ -55,7 +55,12 @@ pub fn calculate_dr_id_and_args(nonce: u128, replication_factor: u16) -> PostDat
     }
 }
 
-pub fn construct_dr(dr_args: PostDataRequestArgs, seda_payload: Vec<u8>, height: u64) -> DataRequestContract {
+pub fn construct_dr(
+    dr_args: PostDataRequestArgs,
+    seda_payload: Vec<u8>,
+    height: u64,
+    amount: u128,
+) -> DataRequestContract {
     let version = Version {
         major: 0,
         minor: 0,
@@ -84,6 +89,8 @@ pub fn construct_dr(dr_args: PostDataRequestArgs, seda_payload: Vec<u8>, height:
             commits: Default::default(),
             payback_address: payback_address.into(),
             height,
+            posted_gas_price: Uint128::from(amount)
+                / (Uint128::from(dr_args.exec_gas_limit) + Uint128::from(dr_args.tally_gas_limit)),
         },
         reveals: Default::default(),
     }

--- a/contract/src/msgs/data_requests/tests/mod.rs
+++ b/contract/src/msgs/data_requests/tests/mod.rs
@@ -20,15 +20,15 @@ fn check_data_request_id() {
     //     "exec_inputs": "ZHJfaW5wdXRz",
     //     "exec_gas_limit": 10_000_000_000_000,
     //     "tally_program_id":
-    // "3a1561a3d854e446801b339c137f87dbd2238f481449c00d3470cfcc2a4e24a1",
+    // "e36e73257ac61c4e7126922411591d8558f4e2f6213aca27ef0b1e2ebf05fe35",
     //     "tally_inputs": "dGFsbHlfaW5wdXRz",
     //     "tally_gas_limit": 10_000_000_000_000,
     //     "replication_factor": 1,
     //     "consensus_filter": "AA==",
-    //     "gas_price": 1000,
+    //     "gas_price": 2000,
     //     "memo": "XTtTqpLgvyGr54/+ov83JyG852lp7VqzBrC10UpsIjg="
     //   }
-    let expected_dr_id = "9b7a442ca023779b09ee122d56048fb2f130dd405cfb4e300668840d8dfdf1cc";
+    let expected_dr_id = "b5722604a49dc8b83751890f2e85dae02f5c38c5e86a88e262e62f7e9b292de1";
 
     // compute and check if dr id matches expected value
     let dr = test_helpers::calculate_dr_id_and_args(0, 1);

--- a/contract/src/msgs/data_requests/tests/post_dr.rs
+++ b/contract/src/msgs/data_requests/tests/post_dr.rs
@@ -25,8 +25,12 @@ fn works() {
 
     // post a data request
     let dr = test_helpers::calculate_dr_id_and_args(1, 1);
+    let amount = dr
+        .gas_price
+        .checked_mul(Uint128::from(dr.exec_gas_limit + dr.tally_gas_limit))
+        .unwrap();
     let dr_id = anyone
-        .post_data_request(dr.clone(), vec![], vec![1, 2, 3], 1, None)
+        .post_data_request(dr.clone(), vec![], vec![1, 2, 3], 1, Some(amount.into()))
         .unwrap();
 
     // Expect the dr staked to exist and be correct
@@ -46,7 +50,7 @@ fn works() {
     // should be able to fetch data request with id 0x69...
     let received_value = anyone.get_data_request(&dr_id);
     assert_eq!(
-        Some(test_helpers::construct_dr(dr, vec![], 1).base),
+        Some(test_helpers::construct_dr(dr, vec![], 1, amount.into()).base),
         received_value.map(|dr| dr.base)
     );
     let await_commits = anyone.get_data_requests_by_status(DataRequestStatus::Committing, None, 10);

--- a/contract/src/msgs/sorted_set.rs
+++ b/contract/src/msgs/sorted_set.rs
@@ -70,7 +70,7 @@ impl TryFrom<&DataRequestBase> for IndexKey {
 
     fn try_from(value: &DataRequestBase) -> Result<Self, Self::Error> {
         let dr_id = Hash::from_hex_str(&value.id)?;
-        Ok(Self::new(value.gas_price, value.height, dr_id))
+        Ok(Self::new(value.posted_gas_price, value.height, dr_id))
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -138,6 +138,7 @@ fn create_data_request(
             commits: Default::default(),
             payback_address: Default::default(),
             height: rand::random(),
+            posted_gas_price: 10u128.into(),
         },
         reveals,
     }


### PR DESCRIPTION
## Motivation

Added `posted_gas_price` field to enable gas price forwarding, allowing solvers and other components to increase the minimum gas price defined by other parties when forwarding data requests.

## Explanation of Changes

- Added `posted_gas_price: U128` field to `DataRequestBase` that captures actual gas price paid (`funds / total_gas_limit`)
- Updated posting logic to calculate and store `posted_gas_price`
- Removed redundant `InsufficientFunds` check that was impossible to fail
- Sort data requests by `posted_gas_price` instead of `gas_price`

## Testing

```bash
cargo test -p seda-common
cargo test -p seda-contract
```

## Dependency Chain
[chain]: https://github.com/sedaprotocol/seda-chain
[explorer]: https://github.com/sedaprotocol/seda-explorer
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[sdk]: https://github.com/sedaprotocol/seda-sdk

- [ ] [chain][chain] - Handle new field in messages/events
- [ ] [explorer/indexer][explorer] - Display new field
- [ ] [overlay-ts][overlay-ts] - Implement gas price forwarding
- [ ] [overlay-rs][overlay-rs] - Implement gas price forwarding
- [x] [sdk][sdk] - Expose new field in types, not should continue to work

## Related PRs and Issues

N/A