### PR TITLE
chore: optimize wasm binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.83.0"
 edition = "2021"
 
 [profile.release]
-opt-level = 3
+opt-level = "z"
 debug = false
 rpath = false
 lto = true
@@ -21,7 +21,11 @@ debug-assertions = false
 codegen-units = 1
 panic = 'abort'
 incremental = false
-overflow-checks = true
+strip = true
+
+[profile.debug-size]
+inherits = "release"
+debug = true
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -100,7 +100,7 @@ fn wasm_opt(sh: &Shell) -> Result<()> {
     wasm(sh)?;
     cmd!(
 			sh,
-			"wasm-opt -Os --signext-lowering target/wasm32-unknown-unknown/release/seda_contract.wasm -o target/seda_contract.wasm"
+			"wasm-opt -Oz --monomorphize -O3 --enable-bulk-memory --signext-lowering target/wasm32-unknown-unknown/release/seda_contract.wasm -o target/seda_contract.wasm"
 		)
     .run()?;
     Ok(())


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The WASM size was getting too big.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Turn on some more size optimization settings- from speed settings on the rust side.
Do more strict size optimization on wasm-opt side.
Also turn on some other wasm-opt settings that help.
Bulk memory was required on my machine- i suppose cause im on the latest version of rust.
No version changes we can just re-create the latest release.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

We should test on planet

## Dependency Chain
[chain]: https://github.com/sedaprotocol/seda-chain
[explorer]: https://github.com/sedaprotocol/seda-explorer
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[sdk]: https://github.com/sedaprotocol/seda-sdk

Think about the changes(msgs, events, limits, etc.) made in this PR and see if you need to make an issue/pr on the following repos.

- [ ] [chain][chain]
- [ ] [explorer/indexer][explorer]
- [ ] [overlay-ts][overlay-ts]
- [ ] [overlay-rs][overlay-rs]
- [ ] [sdk][sdk]

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A