### PR TITLE
fix(remove-request): no panic if proxy reward amount is 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.15"
+version = "1.0.16"
 edition = "2021"
 rust-version.workspace = true
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.15"
+version = "1.0.16"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/msgs/data_requests/sudo/remove_requests.rs
+++ b/contract/src/msgs/data_requests/sudo/remove_requests.rs
@@ -95,11 +95,28 @@ fn remove_request_and_process_distributions(
         match &message {
             DistributionMessage::Burn(distribution_burn) => {
                 let amount_to_burn = distribution_burn.amount.min(dr_escrow.amount);
+
+                if amount_to_burn.is_zero() {
+                    event = event.add_attribute("burn", amount_to_burn.to_string());
+                    continue 'process_message;
+                }
+
                 bank_messages.push(burn(amount_to_burn, token, &mut dr_escrow));
                 event = event.add_attribute("burn", amount_to_burn.to_string());
             }
             DistributionMessage::DataProxyReward(distribution_send) => {
                 let amount_to_reward = distribution_send.amount.min(dr_escrow.amount);
+                if amount_to_reward.is_zero() {
+                    event = event.add_attribute(
+                        "data_proxy_reward",
+                        json_str!(
+                            "amount": amount_to_reward,
+                            "payout_address": distribution_send.payout_address,
+                            "public_key": distribution_send.public_key,
+                        ),
+                    );
+                    continue 'process_message;
+                }
 
                 if let Ok(addr) = deps.api.addr_validate(&distribution_send.payout_address) {
                     bank_messages.push(BankMsg::Send {

--- a/contract/src/msgs/data_requests/tests/remove_dr.rs
+++ b/contract/src/msgs/data_requests/tests/remove_dr.rs
@@ -444,3 +444,103 @@ fn unstake_before_dr_removal_still_rewards_staker() {
     // bob can withdraw the reward
     bob.withdraw().unwrap();
 }
+
+#[test]
+fn works_with_data_proxy_fee_of_0() {
+    let test_info = TestInfo::init();
+
+    // post a data request
+    let alice = test_info.new_account("alice", 22);
+    let executor = test_info.new_executor("exec", 51, 1);
+    let dr = test_helpers::calculate_dr_id_and_args(1, 1);
+    let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
+
+    // alice commits a data result
+    let executor_reveal = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![],
+    };
+    let executor_reveal_message = executor.create_reveal_message(executor_reveal);
+    executor.commit_result(&dr_id, &executor_reveal_message).unwrap();
+    executor.reveal_result(executor_reveal_message).unwrap();
+
+    // owner removes a data result
+    // data proxy reward goes to executors SEDA address
+    // reward goes to executors identity
+    // invalid identities and address are burned
+    // non staked executor is not rewarded
+    // remainder refunds to alice
+    let (_, proxy) = new_public_key();
+    test_info
+        .creator()
+        .remove_data_request(
+            dr_id,
+            vec![
+                DistributionMessage::Burn(DistributionBurn { amount: 1u128.into() }),
+                // valid data proxy reward
+                DistributionMessage::DataProxyReward(DistributionDataProxyReward {
+                    payout_address: executor.addr().to_string(),
+                    amount:         0u128.into(),
+                    public_key:     proxy.to_hex(),
+                }),
+            ],
+        )
+        .unwrap();
+    // Alice seda - stake amount minus the rewards
+    let alice_expected_balance = seda_to_aseda(22.into()) - 1;
+    assert_eq!(alice_expected_balance, test_info.executor_balance("alice"));
+}
+
+#[test]
+fn works_with_burn_amount_of_0() {
+    let test_info = TestInfo::init();
+
+    // post a data request
+    let alice = test_info.new_account("alice", 22);
+    let executor = test_info.new_executor("exec", 51, 1);
+    let dr = test_helpers::calculate_dr_id_and_args(1, 1);
+    let dr_id = alice.post_data_request(dr, vec![], vec![], 1, None).unwrap();
+
+    // alice commits a data result
+    let executor_reveal = RevealBody {
+        dr_id:             dr_id.clone(),
+        dr_block_height:   1,
+        reveal:            "10".hash().into(),
+        gas_used:          0,
+        exit_code:         0,
+        proxy_public_keys: vec![],
+    };
+    let executor_reveal_message = executor.create_reveal_message(executor_reveal);
+    executor.commit_result(&dr_id, &executor_reveal_message).unwrap();
+    executor.reveal_result(executor_reveal_message).unwrap();
+
+    // owner removes a data result
+    // data proxy reward goes to executors SEDA address
+    // reward goes to executors identity
+    // invalid identities and address are burned
+    // non staked executor is not rewarded
+    // remainder refunds to alice
+    let (_, proxy) = new_public_key();
+    test_info
+        .creator()
+        .remove_data_request(
+            dr_id,
+            vec![
+                DistributionMessage::Burn(DistributionBurn { amount: 0u128.into() }),
+                // valid data proxy reward
+                DistributionMessage::DataProxyReward(DistributionDataProxyReward {
+                    payout_address: executor.addr().to_string(),
+                    amount:         1u128.into(),
+                    public_key:     proxy.to_hex(),
+                }),
+            ],
+        )
+        .unwrap();
+    // Alice seda - stake amount minus the rewards
+    let alice_expected_balance = seda_to_aseda(22.into()) - 1;
+    assert_eq!(alice_expected_balance, test_info.executor_balance("alice"));
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So we can have functional 0 fee data proxy operators.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Checks if the amount is 0 and if it is it continues on the loop after emitting the event.

We could do this check in other places as well- but it should never be 0 in those places right?

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Added a new test that caused it to fail and it now passes.

## Dependency Chain
[chain]: https://github.com/sedaprotocol/seda-chain
[explorer]: https://github.com/sedaprotocol/seda-explorer
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[sdk]: https://github.com/sedaprotocol/seda-sdk

Think about the changes(msgs, events, limits, etc.) made in this PR and see if you need to make an issue/pr on the following repos.

- [ ] [chain][chain]
- [ ] [explorer/indexer][explorer]
- [ ] [overlay-ts][overlay-ts]
- [ ] [overlay-rs][overlay-rs]
- [ ] [sdk][sdk]

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A