### PR TITLE
Data request pool drainage in preparation to upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "seda-common"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "seda-contract"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-common"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2021"
 rust-version.workspace = true
 

--- a/common/src/msgs/owner/execute/drain_data_request_pool.rs
+++ b/common/src/msgs/owner/execute/drain_data_request_pool.rs
@@ -1,0 +1,12 @@
+#[cfg_attr(feature = "cosmwasm", cosmwasm_schema::cw_serde)]
+#[cfg_attr(not(feature = "cosmwasm"), derive(serde::Serialize, Debug, PartialEq))]
+#[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
+pub struct Execute {
+    pub target_height: u64,
+}
+
+impl From<Execute> for crate::msgs::ExecuteMsg {
+    fn from(value: Execute) -> Self {
+        super::ExecuteMsg::DrainDataRequestPool(value).into()
+    }
+}

--- a/common/src/msgs/owner/execute/drain_data_request_pool.rs
+++ b/common/src/msgs/owner/execute/drain_data_request_pool.rs
@@ -3,6 +3,7 @@
 #[cfg_attr(not(feature = "cosmwasm"), serde(rename_all = "snake_case"))]
 pub struct Execute {
     pub target_height: u64,
+    pub buffer:        u64,
 }
 
 impl From<Execute> for crate::msgs::ExecuteMsg {

--- a/common/src/msgs/owner/execute/mod.rs
+++ b/common/src/msgs/owner/execute/mod.rs
@@ -1,5 +1,6 @@
 pub mod accept_ownership;
 pub mod add_to_allowlist;
+pub mod drain_data_request_pool;
 pub mod pause;
 pub mod remove_from_allowlist;
 pub mod transfer_ownership;
@@ -17,6 +18,7 @@ pub enum ExecuteMsg {
     RemoveFromAllowlist(remove_from_allowlist::Execute),
     Pause(pause::Execute),
     Unpause(unpause::Execute),
+    DrainDataRequestPool(drain_data_request_pool::Execute),
 }
 
 impl From<ExecuteMsg> for crate::msgs::ExecuteMsg {

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-contract"
-version = "1.0.16"
+version = "1.0.17"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -20,7 +20,7 @@ use crate::{
         QueryHandler,
         SudoHandler,
     },
-    state::{CHAIN_ID, PAUSED, TOKEN},
+    state::{CHAIN_ID, DR_POOL_DRAIN_TARGET, PAUSED, TOKEN},
 };
 
 // version info for migration info
@@ -48,6 +48,7 @@ pub fn instantiate(
     CHAIN_ID.save(deps.storage, &msg.chain_id)?;
     PENDING_OWNER.save(deps.storage, &None)?;
     PAUSED.save(deps.storage, &false)?;
+    DR_POOL_DRAIN_TARGET.save(deps.storage, &0)?;
 
     let init_staking_config = msg.staking_config.unwrap_or(StakingConfig {
         minimum_stake:     INITIAL_MINIMUM_STAKE,
@@ -125,6 +126,10 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, Contra
     }
 
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    if DR_POOL_DRAIN_TARGET.may_load(deps.storage)?.is_none() {
+        DR_POOL_DRAIN_TARGET.save(deps.storage, &0)?;
+    }
 
     Ok(Response::new()
         .add_attribute("method", "migrate")

--- a/contract/src/contract.rs
+++ b/contract/src/contract.rs
@@ -20,7 +20,7 @@ use crate::{
         QueryHandler,
         SudoHandler,
     },
-    state::{CHAIN_ID, DR_POOL_DRAIN_TARGET, PAUSED, TOKEN},
+    state::{CHAIN_ID, DR_POOL_DRAIN_BUFFER, DR_POOL_DRAIN_TARGET, PAUSED, TOKEN},
 };
 
 // version info for migration info
@@ -49,6 +49,7 @@ pub fn instantiate(
     PENDING_OWNER.save(deps.storage, &None)?;
     PAUSED.save(deps.storage, &false)?;
     DR_POOL_DRAIN_TARGET.save(deps.storage, &0)?;
+    DR_POOL_DRAIN_BUFFER.save(deps.storage, &5)?;
 
     let init_staking_config = msg.staking_config.unwrap_or(StakingConfig {
         minimum_stake:     INITIAL_MINIMUM_STAKE,
@@ -129,6 +130,9 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, Contra
 
     if DR_POOL_DRAIN_TARGET.may_load(deps.storage)?.is_none() {
         DR_POOL_DRAIN_TARGET.save(deps.storage, &0)?;
+    }
+    if DR_POOL_DRAIN_BUFFER.may_load(deps.storage)?.is_none() {
+        DR_POOL_DRAIN_BUFFER.save(deps.storage, &5)?;
     }
 
     Ok(Response::new()

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -86,6 +86,8 @@ pub enum ContractError {
     InvalidPublicKeyLength(usize),
     #[error("Contract paused: cannot perform operation `{0}`")]
     ContractPaused(String),
+    #[error("Cannot post request: Data request pool is draining")]
+    DataRequestPoolDraining,
     #[error("Contract not paused: cannot unpause")]
     ContractNotPaused,
     #[error("ZeroMinimumStakeToRegister: Minimum stake to register cannot be zero")]

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -92,6 +92,8 @@ pub enum ContractError {
     ContractNotPaused,
     #[error("ZeroMinimumStakeToRegister: Minimum stake to register cannot be zero")]
     ZeroMinimumStakeToRegister,
+    #[error("DrainBufferTooLow: Drain buffer {0} is lower than the minimum 5")]
+    DrainBufferTooLow(u64),
 
     #[error("GasPriceTooLow: Gas price {0} is lower than the minimum {MIN_GAS_PRICE}")]
     GasPriceTooLow(Uint128),

--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -7,7 +7,7 @@ use crate::{
         consts::{MAX_REPLICATION_FACTOR, MIN_EXEC_GAS_LIMIT, MIN_GAS_PRICE, MIN_TALLY_GAS_LIMIT},
         state::DR_CONFIG,
     },
-    state::{DR_POOL_DRAIN_TARGET, TOKEN},
+    state::{DR_POOL_DRAIN_BUFFER, DR_POOL_DRAIN_TARGET, TOKEN},
     utils::get_attached_funds,
 };
 
@@ -16,11 +16,13 @@ impl ExecuteHandler for execute::post_request::Execute {
     fn execute(self, deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
         let dr_config = DR_CONFIG.load(deps.storage)?;
 
+        // Check if the data request pool is draining.
         let target = DR_POOL_DRAIN_TARGET.load(deps.storage)?;
         if target > 0 {
-            // We add 5 blocks as a buffer.
-            let max_blocks_until_expiration: u64 =
-                dr_config.commit_timeout_in_blocks.get() as u64 + dr_config.reveal_timeout_in_blocks.get() as u64 + 5;
+            let buffer = DR_POOL_DRAIN_BUFFER.load(deps.storage)?;
+            let max_blocks_until_expiration: u64 = dr_config.commit_timeout_in_blocks.get() as u64
+                + dr_config.reveal_timeout_in_blocks.get() as u64
+                + buffer;
             if target <= env.block.height + max_blocks_until_expiration {
                 return Err(ContractError::DataRequestPoolDraining);
             }

--- a/contract/src/msgs/data_requests/execute/post_request.rs
+++ b/contract/src/msgs/data_requests/execute/post_request.rs
@@ -7,13 +7,25 @@ use crate::{
         consts::{MAX_REPLICATION_FACTOR, MIN_EXEC_GAS_LIMIT, MIN_GAS_PRICE, MIN_TALLY_GAS_LIMIT},
         state::DR_CONFIG,
     },
-    state::TOKEN,
+    state::{DR_POOL_DRAIN_TARGET, TOKEN},
     utils::get_attached_funds,
 };
 
 impl ExecuteHandler for execute::post_request::Execute {
     /// Posts a data request to the pool
     fn execute(self, deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+        let dr_config = DR_CONFIG.load(deps.storage)?;
+
+        let target = DR_POOL_DRAIN_TARGET.load(deps.storage)?;
+        if target > 0 {
+            // We add 5 blocks as a buffer.
+            let max_blocks_until_expiration: u64 =
+                dr_config.commit_timeout_in_blocks.get() as u64 + dr_config.reveal_timeout_in_blocks.get() as u64 + 5;
+            if target <= env.block.height + max_blocks_until_expiration {
+                return Err(ContractError::DataRequestPoolDraining);
+            }
+        }
+
         // require the replication to be non-zero
         if self.posted_dr.replication_factor == 0 {
             return Err(ContractError::DataRequestReplicationFactorZero);
@@ -48,7 +60,6 @@ impl ExecuteHandler for execute::post_request::Execute {
             return Err(ContractError::DataRequestVersionInvalid);
         }
         // check the size limits of the dr
-        let dr_config = DR_CONFIG.load(deps.storage)?;
         if self.posted_dr.exec_inputs.len() > dr_config.exec_input_limit_in_bytes.get() as usize {
             return Err(ContractError::DrFieldTooBig(
                 "exec inputs",

--- a/contract/src/msgs/owner/execute/drain_data_request_pool.rs
+++ b/contract/src/msgs/owner/execute/drain_data_request_pool.rs
@@ -5,7 +5,7 @@ use crate::{
     contract::CONTRACT_VERSION,
     error::ContractError,
     msgs::{owner::state::OWNER, ExecuteHandler},
-    state::{DR_POOL_DRAIN_TARGET, PAUSED},
+    state::{DR_POOL_DRAIN_BUFFER, DR_POOL_DRAIN_TARGET, PAUSED},
 };
 
 impl ExecuteHandler for execute::drain_data_request_pool::Execute {
@@ -21,6 +21,13 @@ impl ExecuteHandler for execute::drain_data_request_pool::Execute {
         }
 
         DR_POOL_DRAIN_TARGET.save(deps.storage, &self.target_height)?;
+
+        if self.buffer != 0 {
+            if self.buffer < 5 {
+                return Err(ContractError::DrainBufferTooLow(self.buffer));
+            }
+            DR_POOL_DRAIN_BUFFER.save(deps.storage, &self.buffer)?;
+        }
 
         Ok(Response::new()
             .add_attribute("action", "drain_data_request_pool")

--- a/contract/src/msgs/owner/execute/drain_data_request_pool.rs
+++ b/contract/src/msgs/owner/execute/drain_data_request_pool.rs
@@ -1,0 +1,32 @@
+use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
+use seda_common::msgs::owner::execute;
+
+use crate::{
+    contract::CONTRACT_VERSION,
+    error::ContractError,
+    msgs::{owner::state::OWNER, ExecuteHandler},
+    state::{DR_POOL_DRAIN_TARGET, PAUSED},
+};
+
+impl ExecuteHandler for execute::drain_data_request_pool::Execute {
+    fn execute(self, deps: DepsMut, _: Env, info: MessageInfo) -> Result<Response, ContractError> {
+        let owner = OWNER.load(deps.storage)?;
+        if info.sender != owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let paused = PAUSED.load(deps.storage)?;
+        if paused {
+            return Err(ContractError::ContractPaused("pause".to_string()));
+        }
+
+        DR_POOL_DRAIN_TARGET.save(deps.storage, &self.target_height)?;
+
+        Ok(Response::new()
+            .add_attribute("action", "drain_data_request_pool")
+            .add_event(Event::new("seda-contract").add_attributes([
+                ("version", CONTRACT_VERSION.to_string()),
+                ("target_height", self.target_height.to_string()),
+            ])))
+    }
+}

--- a/contract/src/msgs/owner/execute/mod.rs
+++ b/contract/src/msgs/owner/execute/mod.rs
@@ -7,6 +7,7 @@ use super::{
 
 pub(in crate::msgs::owner) mod accept_ownership;
 pub(in crate::msgs::owner) mod add_to_allowlist;
+pub mod drain_data_request_pool;
 pub mod pause;
 pub(in crate::msgs::owner) mod remove_from_allowlist;
 pub(in crate::msgs::owner) mod transfer_ownership;
@@ -21,6 +22,7 @@ impl ExecuteHandler for ExecuteMsg {
             ExecuteMsg::RemoveFromAllowlist(msg) => msg.execute(deps, env, info),
             ExecuteMsg::Pause(msg) => msg.execute(deps, env, info),
             ExecuteMsg::Unpause(msg) => msg.execute(deps, env, info),
+            ExecuteMsg::DrainDataRequestPool(msg) => msg.execute(deps, env, info),
         }
     }
 }

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -11,6 +11,10 @@ pub const PAUSED: Item<bool> = Item::new("paused");
 /// PostDataRequest messages are blocked accordingly.
 pub const DR_POOL_DRAIN_TARGET: Item<u64> = Item::new("dr_pool_drain_target");
 
+/// Set to 5 by default with minimum of 5. This is the number of buffer blocks
+/// added to the drain period.
+pub const DR_POOL_DRAIN_BUFFER: Item<u64> = Item::new("dr_pool_drain_buffer");
+
 /// Token denom used for staking (e.g., `aseda`).
 pub const TOKEN: Item<String> = Item::new("token");
 

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -6,6 +6,11 @@ use crate::types::PublicKey;
 /// Flag to indicate if the contract is paused.
 pub const PAUSED: Item<bool> = Item::new("paused");
 
+/// Set to 0 by default. If set to a positive value, it is interpreted as the
+/// target block height by which the data request pool should be emptied.
+/// PostDataRequest messages are blocked accordingly.
+pub const DR_POOL_DRAIN_TARGET: Item<u64> = Item::new("dr_pool_drain_target");
+
 /// Token denom used for staking (e.g., `aseda`).
 pub const TOKEN: Item<String> = Item::new("token");
 


### PR DESCRIPTION
## Explanation of Changes

We add an owner-controlled command that initiates draining the data request pool by blocking PostDataRequests based on the target height. 

## Testing

Added an integration test that simulates the drainage & upgrade process in https://github.com/sedaprotocol/seda-chain/pull/642.

## Related PRs and Issues

Closes #313